### PR TITLE
Add a KafkaMessageKey annotation and builder to process that

### DIFF
--- a/src/main/java/com/rackspace/salus/common/messaging/KafkaMessageKey.java
+++ b/src/main/java/com/rackspace/salus/common/messaging/KafkaMessageKey.java
@@ -1,0 +1,20 @@
+package com.rackspace.salus.common.messaging;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares the properties of the annotated class that will be used to compose a Kafka message key
+ * using {@link KafkaMessageKeyBuilder}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface KafkaMessageKey {
+
+  /**
+   * the property names of this class to compose into the Kafka message key
+   */
+  String[] properties();
+}

--- a/src/main/java/com/rackspace/salus/common/messaging/KafkaMessageKeyBuilder.java
+++ b/src/main/java/com/rackspace/salus/common/messaging/KafkaMessageKeyBuilder.java
@@ -1,0 +1,57 @@
+package com.rackspace.salus.common.messaging;
+
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.InvalidPropertyException;
+import org.springframework.beans.PropertyAccessorFactory;
+import org.springframework.util.Assert;
+
+/**
+ * This utility class supports building Kafka message keys from objects annotated with
+ * {@link KafkaMessageKey}.
+ * <p>
+ *   Note that this is quite similar in concept to the <code>message-key-expression</code>
+ *   supported by <a href="https://docs.spring.io/spring-kafka/reference/html/_spring_integration.html#si-outbound">Spring Kafka's Outbound Channel Adapter</a>.
+ *   In contrast, this processor is purposely simpler and more focused on building strings suitable
+ *   as "primary keys" in Kafka Streams tables.
+ * </p>
+ */
+public class KafkaMessageKeyBuilder {
+
+  public static final String SEPARATOR = ":";
+
+  /**
+   * Builds a Kafka message key by extracting the properties declared in the annotated eventObject
+   * and composing a string out of those.
+   *
+   * @param eventObject an object whose class is annotated with {@link KafkaMessageKey}
+   * @return a string composed of the property values extracted from the given eventObject
+   */
+  public static String buildMessageKey(Object eventObject) {
+    final Class<?> eventClass = eventObject.getClass();
+
+    final KafkaMessageKey kafkaMessageKey = eventClass.getAnnotation(KafkaMessageKey.class);
+    Assert.notNull(kafkaMessageKey, "Given object is missing KafkaMessageKey annotation");
+
+    final String[] properties = kafkaMessageKey.properties();
+    Assert.notEmpty(properties, "KafkaMessageKey annotation is missing properties");
+
+    final BeanWrapper propertyAccessor = PropertyAccessorFactory.forBeanPropertyAccess(eventObject);
+
+    final String[] parts = new String[properties.length];
+    for (int i = 0; i < parts.length; i++) {
+      final Object value;
+      try {
+        value = propertyAccessor.getPropertyValue(properties[i]);
+      } catch (InvalidPropertyException e) {
+        throw new IllegalArgumentException(
+            String.format("Object is missing expected message key property: %s", properties[i]));
+      }
+      parts[i] = value != null ?
+          value.toString() :
+          // fallback to a "null" string but convey the field name to help us debug
+          "null-"+properties[i];
+    }
+
+    return String.join(SEPARATOR, parts);
+  }
+}

--- a/src/test/java/com/rackspace/salus/common/messaging/KafkaMessageKeyBuilderTest.java
+++ b/src/test/java/com/rackspace/salus/common/messaging/KafkaMessageKeyBuilderTest.java
@@ -1,0 +1,91 @@
+package com.rackspace.salus.common.messaging;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import lombok.Data;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+public class KafkaMessageKeyBuilderTest {
+
+  @KafkaMessageKey(properties = "id")
+  @Data
+  static class OneProp {
+    String id;
+  }
+
+  @Test
+  public void oneProp() {
+    final OneProp obj = new OneProp();
+    obj.setId("testing-1");
+
+    final String key = KafkaMessageKeyBuilder.buildMessageKey(obj);
+    assertThat(key, equalTo("testing-1"));
+  }
+
+  @KafkaMessageKey(properties = {"id", "count", "enabled"})
+  @Data
+  static class MultipleProps {
+    String id;
+    int count;
+    boolean enabled;
+  }
+
+  @Test
+  public void multipleProps() {
+    final MultipleProps obj = new MultipleProps();
+    obj.setId("testing-2");
+    obj.setCount(3);
+    obj.setEnabled(true);
+
+    final String key = KafkaMessageKeyBuilder.buildMessageKey(obj);
+    assertThat(key, Matchers.equalTo("testing-2:3:true"));
+  }
+
+  @Test
+  public void withNullProp() {
+    final MultipleProps obj = new MultipleProps();
+    // leave id unset, so it's null
+    obj.setCount(5);
+    obj.setEnabled(false);
+
+    final String key = KafkaMessageKeyBuilder.buildMessageKey(obj);
+    assertThat(key, Matchers.equalTo("null-id:5:false"));
+  }
+
+  @Data
+  static class MissingAnnotation{
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void missingAnnotation() {
+    final MissingAnnotation obj = new MissingAnnotation();
+
+    KafkaMessageKeyBuilder.buildMessageKey(obj);
+  }
+
+  @KafkaMessageKey(properties = {})
+  static class EmptyPropsDeclared{}
+
+  @Test(expected = IllegalArgumentException.class)
+  public void emptyPropsDeclared() {
+    final EmptyPropsDeclared obj = new EmptyPropsDeclared();
+
+    KafkaMessageKeyBuilder.buildMessageKey(obj);
+  }
+
+
+  @KafkaMessageKey(properties = "id")
+  static class InvalidProp {
+    String notId;
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void invalidProp() {
+    final InvalidProp obj = new InvalidProp();
+
+    KafkaMessageKeyBuilder.buildMessageKey(obj);
+  }
+
+}


### PR DESCRIPTION
# Resolves

Related to the epic SALUS-112

# What

Adds a (proposed) strategy to both declare/document the Kafka message keys for a given event class, but also provides a means to consistently build the key itself.

# How

Adds a custom annotation to declare the properties to include within that event's key. It also adds a utility class to process an instance of those annotated classes into a message key string. I considered declaring it as a Spring component/service, but it doesn't contain any business logic or similar that warrants being a full-blown component.

## How to test

A unit test has been added.

# Why

An alternative could be to simply document the intended keys and perform string concatenations, but the annotation and utility both document and solve the need.

# TODO

none