### PR TITLE
Move Hashing util from etcd-adapter

### DIFF
--- a/src/main/java/com/rackspace/salus/common/util/KeyHashing.java
+++ b/src/main/java/com/rackspace/salus/common/util/KeyHashing.java
@@ -1,0 +1,55 @@
+/*
+ *    Copyright 2018 Rackspace US, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package com.rackspace.salus.telemetry.etcd.config;
+
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class KeyHashing {
+
+    private final String DELIMITER = ":";
+
+    public HashFunction hashFunction() {
+        return Hashing.sha256();
+    }
+
+    /**
+     * Performs a hashing function on the provided string and returns the output.
+     *
+     * @param values The string(s) to be hashed.  Colon separated if multiple are provided.
+     * @return The hashed result.
+     */
+    public String hash(String... values) {
+        String value = Arrays.stream(values).collect(Collectors.joining(DELIMITER));
+        return hashFunction().hashString(value, StandardCharsets.UTF_8).toString();
+    }
+
+    /**
+     * @return the bit size of the current hash algorithm
+     */
+    public int bits() {
+        return hashFunction().bits();
+    }
+}

--- a/src/test/java/com/rackspace/salus/common/util/KeyHashingTest.java
+++ b/src/test/java/com/rackspace/salus/common/util/KeyHashingTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.common.util;
+
+import com.rackspace.salus.telemetry.etcd.config.KeyHashing;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class KeyHashingTest {
+
+    @Test
+    public void singleValue() {
+        KeyHashing hashing = new KeyHashing();
+        String value = "thisisatest";
+        String hashedValue = hashing.hash(value);
+        assertThat(hashedValue, notNullValue());
+    }
+
+    @Test
+    public void multipleValues() {
+        String[] values = new String[3];
+        values[0] = "one";
+        values[1] = "two";
+        values[2] = "three";
+
+        String value = String.format("%s:%s:%s", values[0], values[1], values[2]);
+
+        KeyHashing hashing = new KeyHashing();
+
+        String hashedValues = hashing.hash(values);
+        String hashedValue = hashing.hash(value);
+
+        assertThat(hashedValue, notNullValue());
+        assertThat(hashedValues, notNullValue());
+        assertThat(hashedValues, equalTo(hashedValue));
+    }
+}


### PR DESCRIPTION
Brings in the hashing functions from `etcd-adapter`.

Modifies it to accept multiple strings.

Adds some basic test cases.