### PR TITLE
Add buildMessageKeyFromParts to KafkaMessageKeyBuilder

### DIFF
--- a/src/main/java/com/rackspace/salus/common/messaging/KafkaMessageKeyBuilder.java
+++ b/src/main/java/com/rackspace/salus/common/messaging/KafkaMessageKeyBuilder.java
@@ -1,5 +1,6 @@
 package com.rackspace.salus.common.messaging;
 
+import java.util.Objects;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.InvalidPropertyException;
 import org.springframework.beans.PropertyAccessorFactory;
@@ -53,5 +54,23 @@ public class KafkaMessageKeyBuilder {
     }
 
     return String.join(SEPARATOR, parts);
+  }
+
+  /**
+   * Builds a Kafka message key by composing a string out of the {@code toString} of each
+   * given object.
+   *
+   * @param parts the components of the kafka key to build
+   * @return a string composed of the stringified parts given
+   */
+  public static String buildMessageKeyFromParts(Object... parts) {
+    Assert.notEmpty(parts, "At least one part is required");
+
+    final String[] strings = new String[parts.length];
+    for (int i = 0; i < parts.length; i++) {
+      strings[i] = Objects.toString(parts[i]);
+    }
+
+    return String.join(SEPARATOR, strings);
   }
 }

--- a/src/test/java/com/rackspace/salus/common/messaging/KafkaMessageKeyBuilderTest.java
+++ b/src/test/java/com/rackspace/salus/common/messaging/KafkaMessageKeyBuilderTest.java
@@ -88,4 +88,36 @@ public class KafkaMessageKeyBuilderTest {
     KafkaMessageKeyBuilder.buildMessageKey(obj);
   }
 
+  @Test
+  public void buildMessageKeyFromParts_fromStringParts() {
+    final String result = KafkaMessageKeyBuilder.buildMessageKeyFromParts("one", "two");
+
+    assertThat(result, equalTo("one:two"));
+  }
+
+  @Test
+  public void buildMessageKeyFromParts_fromOnePart() {
+    final String result = KafkaMessageKeyBuilder.buildMessageKeyFromParts("one");
+
+    assertThat(result, equalTo("one"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void buildMessageKeyFromParts_fromEmptyParts() {
+    KafkaMessageKeyBuilder.buildMessageKeyFromParts();
+  }
+
+  @Test
+  public void buildMessageKeyFromParts_fromMixedTypeParts() {
+    final String result = KafkaMessageKeyBuilder.buildMessageKeyFromParts("one", 2, true);
+
+    assertThat(result, equalTo("one:2:true"));
+  }
+
+  @Test
+  public void buildMessageKeyFromParts_nullParts() {
+    final String result = KafkaMessageKeyBuilder.buildMessageKeyFromParts("one", null);
+
+    assertThat(result, equalTo("one:null"));
+  }
 }


### PR DESCRIPTION
# What

Inspired by https://github.com/racker/salus-telemetry-resource-management/pull/1 this adds another utility method for composing a key out of arbitrary parts. This is useful when the constituent fields of the kafka message to send are not readily available at the top level of a POJO.

## How to test

Includes new unit tests
