### PR TITLE
Provide common kafka topics configurability

### DIFF
--- a/src/main/java/com/rackspace/salus/common/messaging/EnableSalusKafkaMessaging.java
+++ b/src/main/java/com/rackspace/salus/common/messaging/EnableSalusKafkaMessaging.java
@@ -1,0 +1,18 @@
+package com.rackspace.salus.common.messaging;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+/**
+ * This annotation can be applied to a Spring Boot application class or any other {@link org.springframework.context.annotation.Configuration}
+ * component where the application is participating in Kafka messaging between or out of a Salus service.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@EnableConfigurationProperties(KafkaTopicProperties.class)
+public @interface EnableSalusKafkaMessaging {
+
+}

--- a/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
+++ b/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
@@ -1,0 +1,29 @@
+package com.rackspace.salus.common.messaging;
+
+import javax.validation.constraints.NotEmpty;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Provides configurability of the Kafka topics used between and out of Salus services.
+ */
+@ConfigurationProperties("kafka-topics")
+@Data
+public class KafkaTopicProperties {
+
+  @NotEmpty
+  String logs = "telemetry.logs.json";
+
+  @NotEmpty
+  String metrics = "telemetry.metrics.json";
+
+  @NotEmpty
+  String events = "telemetry.events.json";
+
+  @NotEmpty
+  String attaches = "telemetry.attaches.json";
+
+  @NotEmpty
+  String resources = "telemetry.resources.json";
+
+}


### PR DESCRIPTION
# What

From discussion in https://github.com/racker/salus-telemetry-resource-management/pull/1 this PR proposes a Spring Boot "Enable" annotation to centralize the activation of kafka topics properties and eventually any other Spring context activations needed across all of our apps that use Kafka.
 
# How

It provides a single annotation that simplifies and abstracts any cross-app Spring configuration. Applications could have done the `@EnableConfigurationProperties` directly, but it would get tedious.

## How to test

Existing unit tests and/or manual testing.

# TODO

I'll also push a PR for https://github.com/racker/salus-telemetry-ambassador that shows how this can be used.