### PR TITLE
Use Google Cloud Build and Google Cloud Storage

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>com.lahsivjar</groupId>
+        <artifactId>gcp-storage-wagon</artifactId>
+        <version>2.0</version>
+    </extension>
+</extensions>

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,19 @@
+steps:
+  - name: 'bash'
+    id: MKDIR
+    entrypoint: '/usr/local/bin/bash'
+    args:
+      - "-c"
+      - |
+        mkdir -p /workspace/blah/snapshot
+
+  - name: 'gcr.io/cloud-builders/mvn'
+    id: DEPLOY
+    args: ['deploy', '-DaltDeploymentRepository=snapshot-repo::default::file:/workspace/blah/snapshot', '-Dmaven.test.skip=true']
+    # This last step, including the -DaltDeployRepository will later be removed.
+    # Hopefully the plugin will be updated soon to correct pushing to work as
+    # well as it can pull.
+    # https://github.com/lahsivjar/gcp-storage-wagon/issues/19
+  - name: 'gcr.io/cloud-builders/gsutil'
+    id: RSYNC to GStorage
+    args: ['-m', 'rsync', '-r', '/workspace/blah/snapshot/', 'gs://salus-mavenrepository/snapshot']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,7 +9,7 @@ steps:
 
   - name: 'gcr.io/cloud-builders/mvn'
     id: DEPLOY
-    args: ['deploy', '-DaltDeploymentRepository=snapshot-repo::default::file:/workspace/blah/snapshot', '-Dmaven.test.skip=true']
+    args: ['deploy', '-DaltDeploymentRepository=snapshot-repo::default::file:/workspace/blah/snapshot']
     # This last step, including the -DaltDeployRepository will later be removed.
     # Hopefully the plugin will be updated soon to correct pushing to work as
     # well as it can pull.

--- a/pom.xml
+++ b/pom.xml
@@ -92,13 +92,26 @@
     </dependencies>
   </dependencyManagement>
 
-
-<distributionManagement>
-    <snapshotRepository>
-        <id>snapshots</id>
-        <name>artifactory-artifactory-0-snapshots</name>
-        <url>https://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-snapshot-local</url>
-    </snapshotRepository>
-</distributionManagement>
+  <distributionManagement>
+      <snapshotRepository>
+          <id>salus-snapshot-bucket</id>
+          <url>gs://salus-220516#salus-mavenrepository/snapshot</url>
+      </snapshotRepository>
+      <repository>
+        <id>salus-release-bucket</id>
+        <url>gs://salus-220516#salus-mavenrepository/release</url>
+        <uniqueVersion>true</uniqueVersion>
+      </repository>
+  </distributionManagement>
+  <repositories>
+      <repository>
+          <id>salus-snapshot-bucket</id>
+          <url>gs://salus-220516#salus-mavenrepository/snapshot</url>
+      </repository>
+      <repository>
+          <id>salus-release-bucket</id>
+          <url>gs://salus-220516#salus-mavenrepository/release</url>
+      </repository>
+  </repositories>
 
 </project>


### PR DESCRIPTION
Use Google Builds instead of Jenkins and Google Storage instead of Artifactory

# Resolves

This allows builds and artifact storage to be done in the Google Cloud system. Builds/Checks will be done with every `git push`.

# What
Adds the cloudbuild.yaml and removes the Jenkinsfile.

Adds Google Cloud Storage as a repository.

# How
Using [lahsivjar/gcp-storage-wagon] to pull down the parent pom/snapshots. It has issues pushing them back up so I'm using a "hack" to push them back to the Google Storage bucket. I'm currently working with the developer of the extension to get this working without the final rsync in the cloudbuild.yaml

# Why
1. Migrate away from Jenkins. One less cog in the machine to manage. Let's let the smart folks at Google manage that infra.
2. Migrate away from Artifactory. One less cog in the machine to manage. Let's let the smart folks at Google manage that infra.


# TODO
Follow-up with lahsivjar/gcp-storage-wagon/issues/19 so that we can remove the last `gsutil rsync` from the cloudbuild.yaml and the first step of creating the dir.