### PR TITLE
Use a better properties prefix for kafka topics properties

### DIFF
--- a/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
+++ b/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.common.messaging;
 
 import javax.validation.constraints.NotEmpty;
@@ -7,7 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * Provides configurability of the Kafka topics used between and out of Salus services.
  */
-@ConfigurationProperties("kafka-topics")
+@ConfigurationProperties("salus.kafka.topics")
 @Data
 public class KafkaTopicProperties {
 


### PR DESCRIPTION
# Resolves

Found during SALUS-186

# What

Since Spring Boot is [a little bit inconsistent](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config-relaxed-binding) with the environment variable binding, this hierarchical prefix will definitively map to vars like `SALUS_KAKFA_TOPICS_METRICS`.

# How

Tweak the properties prefix, which currently has no impact on anything since the defaults are what we use throughout.

# TODO

We need to update resource-management and presence-monitor to use these topics properties.