### PR TITLE
Add kafka topic for zone events

### DIFF
--- a/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
+++ b/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
@@ -45,4 +45,7 @@ public class KafkaTopicProperties {
   @NotEmpty
   String monitors = "telemetry.monitors.json";
 
+  @NotEmpty
+  String zones = "telemetry.zones.json";
+
 }


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-263

# What

Added a topic property and default for zone events.