### PR TITLE
Lower log level of "Result of grab txn" to debug

### DIFF
--- a/src/main/java/com/rackspace/salus/common/workpart/services/WorkAllocator.java
+++ b/src/main/java/com/rackspace/salus/common/workpart/services/WorkAllocator.java
@@ -31,6 +31,10 @@ import com.coreos.jetcd.options.PutOption;
 import com.coreos.jetcd.options.WatchOption;
 import com.coreos.jetcd.watch.WatchEvent;
 import com.coreos.jetcd.watch.WatchResponse;
+import com.rackspace.salus.common.workpart.Bits;
+import com.rackspace.salus.common.workpart.Work;
+import com.rackspace.salus.common.workpart.WorkProcessor;
+import com.rackspace.salus.common.workpart.config.WorkerProperties;
 import java.time.Instant;
 import java.util.Deque;
 import java.util.Iterator;
@@ -42,10 +46,6 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import lombok.extern.slf4j.Slf4j;
-import com.rackspace.salus.common.workpart.Bits;
-import com.rackspace.salus.common.workpart.Work;
-import com.rackspace.salus.common.workpart.WorkProcessor;
-import com.rackspace.salus.common.workpart.config.WorkerProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -510,7 +510,7 @@ public class WorkAllocator implements SmartLifecycle {
         )
         .commit()
         .handle((txnResponse, throwable) -> {
-          log.info("Result of grab txn = {}", txnResponse);
+          log.debug("Result of grab txn = {}", txnResponse);
           Boolean retval = true;
           if (throwable != null) {
             log.warn("Failure while committing work grab of {}", workId, throwable);


### PR DESCRIPTION
# What

While watching a build I noticed the unit tests were outputting a lot of logs like

```
15:34:44.632 [pool-99-thread-6] INFO  c.r.s.c.w.services.WorkAllocator - Result of grab txn = header {
  cluster_id: 14841639068965178418
  member_id: 10276657743932975437
  revision: 11
  raft_term: 2
}
succeeded: true
responses {
  response_put {
    header {
      revision: 11
    }
  }
}
responses {
  response_put {
    header {
      revision: 11
    }
  }
}
```

# How

Lowered that log message to debug, which is what it was meant to be. It was probably raised for helping with debugging an issue.

## How to test

Existing unit tests