### PR TITLE
Add CIDR Util

### DIFF
--- a/src/main/java/com/rackspace/salus/common/util/CIDRUtils.java
+++ b/src/main/java/com/rackspace/salus/common/util/CIDRUtils.java
@@ -62,7 +62,7 @@ public class CIDRUtils {
 
       calculate();
     } else {
-      throw new IllegalArgumentException("not an valid CIDR format!");
+      throw new IllegalArgumentException("not a valid CIDR format!");
     }
   }
 

--- a/src/main/java/com/rackspace/salus/common/util/CIDRUtils.java
+++ b/src/main/java/com/rackspace/salus/common/util/CIDRUtils.java
@@ -1,0 +1,144 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013 Edin Dazdarevic (edin.dazdarevic@gmail.com)
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * */
+
+package com.rackspace.salus.common.util;
+
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A class that enables to get an IP range from CIDR specification. It supports
+ * both IPv4 and IPv6.
+ *
+ * https://github.com/edazdarevic/CIDRUtils
+ */
+public class CIDRUtils {
+  private final String cidr;
+
+  private InetAddress inetAddress;
+  private InetAddress startAddress;
+  private InetAddress endAddress;
+  private final int prefixLength;
+
+
+  public CIDRUtils(String cidr) throws UnknownHostException {
+
+    this.cidr = cidr;
+
+    /* split CIDR to address and prefix part */
+    if (this.cidr.contains("/")) {
+      int index = this.cidr.indexOf("/");
+      String addressPart = this.cidr.substring(0, index);
+      String networkPart = this.cidr.substring(index + 1);
+
+      inetAddress = InetAddress.getByName(addressPart);
+      prefixLength = Integer.parseInt(networkPart);
+
+      calculate();
+    } else {
+      throw new IllegalArgumentException("not an valid CIDR format!");
+    }
+  }
+
+
+  private void calculate() throws UnknownHostException {
+
+    ByteBuffer maskBuffer;
+    int targetSize;
+    if (inetAddress.getAddress().length == 4) {
+      maskBuffer =
+          ByteBuffer
+              .allocate(4)
+              .putInt(-1);
+      targetSize = 4;
+    } else {
+      maskBuffer = ByteBuffer.allocate(16)
+          .putLong(-1L)
+          .putLong(-1L);
+      targetSize = 16;
+    }
+
+    BigInteger mask = (new BigInteger(1, maskBuffer.array())).not().shiftRight(prefixLength);
+
+    ByteBuffer buffer = ByteBuffer.wrap(inetAddress.getAddress());
+    BigInteger ipVal = new BigInteger(1, buffer.array());
+
+    BigInteger startIp = ipVal.and(mask);
+    BigInteger endIp = startIp.add(mask.not());
+
+    byte[] startIpArr = toBytes(startIp.toByteArray(), targetSize);
+    byte[] endIpArr = toBytes(endIp.toByteArray(), targetSize);
+
+    this.startAddress = InetAddress.getByAddress(startIpArr);
+    this.endAddress = InetAddress.getByAddress(endIpArr);
+
+  }
+
+  private byte[] toBytes(byte[] array, int targetSize) {
+    int counter = 0;
+    List<Byte> newArr = new ArrayList<Byte>();
+    while (counter < targetSize && (array.length - 1 - counter >= 0)) {
+      newArr.add(0, array[array.length - 1 - counter]);
+      counter++;
+    }
+
+    int size = newArr.size();
+    for (int i = 0; i < (targetSize - size); i++) {
+
+      newArr.add(0, (byte) 0);
+    }
+
+    byte[] ret = new byte[newArr.size()];
+    for (int i = 0; i < newArr.size(); i++) {
+      ret[i] = newArr.get(i);
+    }
+    return ret;
+  }
+
+  public String getNetworkAddress() {
+
+    return this.startAddress.getHostAddress();
+  }
+
+  public String getBroadcastAddress() {
+    return this.endAddress.getHostAddress();
+  }
+
+  public boolean isInRange(String ipAddress) throws UnknownHostException {
+    InetAddress address = InetAddress.getByName(ipAddress);
+    BigInteger start = new BigInteger(1, this.startAddress.getAddress());
+    BigInteger end = new BigInteger(1, this.endAddress.getAddress());
+    BigInteger target = new BigInteger(1, address.getAddress());
+
+    int st = start.compareTo(target);
+    int te = target.compareTo(end);
+
+    return (st == -1 || st == 0) && (te == -1 || te == 0);
+  }
+}


### PR DESCRIPTION
# What

Adds a utility to validate whether a string is valid CIDR format or not.

# How

Stolen from github! - https://github.com/edazdarevic/CIDRUtils

## How to test

I added tests for the custom validation that uses this to https://github.com/racker/salus-telemetry-monitor-management/pull/31 - `ValidCidrListValidatorTest`

# Why

`org.apache.commons.net.util.SubnetUtils` does not support IPv6 - see issues created in 2011 - https://issues.apache.org/jira/browse/NET-405

I couldn't find any other good alternative.  The other similar libraries would either validate an IP and not a range, or validate an ip is within a range, not that the range given is valid.