### PR TITLE
Create localhost property source and extend error attributes config

### DIFF
--- a/src/main/java/com/rackspace/salus/common/env/LocalhostPropertySourceProcessor.java
+++ b/src/main/java/com/rackspace/salus/common/env/LocalhostPropertySourceProcessor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.common.env;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.PropertySource;
+
+/**
+ * Auto-configures a property source for identifying the local node's hostname and IP address.
+ * <p>
+ * The following properties are provided:
+ * <ul>
+ *   <li><code>localhost.name</code> : the hostname of the local node</li>
+ *   <li><code>localhost.address</code> : the IP address of the local node</li>
+ * </ul>
+ * </p>
+ */
+public class LocalhostPropertySourceProcessor implements EnvironmentPostProcessor {
+
+  @Override
+  public void postProcessEnvironment(ConfigurableEnvironment environment,
+                                     SpringApplication application) {
+
+    final InetAddress localHost;
+    try {
+      localHost = InetAddress.getLocalHost();
+    } catch (UnknownHostException e) {
+      throw new IllegalStateException("Unable to locate local host information", e);
+    }
+
+    environment.getPropertySources().addLast(
+        new PropertySource<String>("localhost") {
+          @Override
+          public Object getProperty(String s) {
+            switch (s) {
+              case "localhost.name":
+                return localHost.getHostName();
+              case "localhost.address":
+                return localHost.getHostAddress();
+            }
+            return null;
+          }
+        }
+    );
+  }
+}

--- a/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.common.web;
+
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.ServletWebRequest;
+
+/**
+ * This handler can be used as a base class for
+ * {@link org.springframework.web.bind.annotation.ControllerAdvice} with
+ * {@link org.springframework.web.bind.annotation.ExceptionHandler}'s to generalize the
+ * formatting of a JSON error resposne body that aligns with the standard Spring Boot
+ * error controller.
+ * <p>
+ *   The following shows an example of implementing controller advice with this base class:
+ * </p>
+ * <pre>
+ &#64;ControllerAdvice(basePackages = "com.rackspace.salus.monitor_management.web")
+ &#64;ResponseBody
+ public class RestExceptionHandler extends
+   com.rackspace.salus.common.web.AbstractRestExceptionHandler {
+
+   &#64;Autowired
+   public RestExceptionHandler(ErrorAttributes errorAttributes) {
+     super(errorAttributes);
+   }
+
+   &#64;ExceptionHandler({IllegalArgumentException.class})
+   public ResponseEntity<?> handleBadRequest(HttpServletRequest request) {
+     return respondWith(request, HttpStatus.BAD_REQUEST);
+   }
+   ...
+
+  * </pre>
+ */
+public abstract class AbstractRestExceptionHandler {
+
+  private final ErrorAttributes errorAttributes;
+
+  public AbstractRestExceptionHandler(
+      ErrorAttributes errorAttributes) {
+    this.errorAttributes = errorAttributes;
+  }
+
+  protected ResponseEntity<?> respondWith(HttpServletRequest request,
+                                          HttpStatus status) {
+    Map<String, Object> body = getErrorAttributes(request);
+    body.put("status", status.value());
+    body.put("error", status.getReasonPhrase());
+    return new ResponseEntity<>(body, status);
+  }
+
+  private Map<String, Object> getErrorAttributes(HttpServletRequest request) {
+    final ServletWebRequest webRequest = new ServletWebRequest(request);
+    return errorAttributes.getErrorAttributes(webRequest, false);
+  }
+}

--- a/src/main/java/com/rackspace/salus/common/web/ExtendedErrorAttributesConfig.java
+++ b/src/main/java/com/rackspace/salus/common/web/ExtendedErrorAttributesConfig.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.common.web;
+
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.WebRequest;
+
+/**
+ * When <code>&#64;Import</code>ed, this will register an {@link ErrorAttributes} bean
+ * that augments the standard response content with:
+ * <ul>
+ *   <li><code>app</code> : the value of the <code>spring.application.name</code> property</li>
+ *   <li><code>host</code> : the value of the <code>localhost.name</code> property</li>
+ * </ul>
+ * <p>
+ *   <em>NOTE:</em> this requires <code>spring.application.name</code> to be configured in
+ *   <code>application.yml</code> (or similar), which is why this configuration bean needs
+ *   to be opted in with an <code>&#64;Import</code>.
+ * </p>
+ * @see com.rackspace.salus.common.env.LocalhostPropertySourceProcessor
+ */
+@Configuration
+@EnableConfigurationProperties({ServerProperties.class})
+public class ExtendedErrorAttributesConfig {
+
+  @Bean
+  public ErrorAttributes errorAttributes(ServerProperties serverProperties,
+                                         @Value("${spring.application.name}") String appName,
+                                         @Value("${localhost.name}") String ourHost) {
+    return new DefaultErrorAttributes(serverProperties.getError().isIncludeException()) {
+      @Override
+      public Map<String, Object> getErrorAttributes(WebRequest webRequest,
+                                                    boolean includeStackTrace) {
+        final Map<String, Object> errorAttributes = super
+            .getErrorAttributes(webRequest, includeStackTrace);
+
+        errorAttributes.put("app", appName);
+        errorAttributes.put("host", ourHost);
+
+        return errorAttributes;
+      }
+    };
+  }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.env.EnvironmentPostProcessor=\
+  com.rackspace.salus.common.env.LocalhostPropertySourceProcessor


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-413

# What

From Jira issue:
> Since we have at least one "proxy" layer for all of our API handling (such as api-public), it can be confusing when looking at an error response where the error truly originated. The changes from this issue will augment the standard Spring Boot error JSON response with an "app" and "host" field.

# How

Follows the pattern of Spring Boot's random value property source

https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config-random-values

by auto-configuring a "localhost" property source that simplifies access to the current node's hostname (and IP address). This will consolidate a pattern we've had to repeat in a few places such as

https://github.com/racker/salus-telemetry-ambassador/blob/master/src/main/java/com/rackspace/salus/telemetry/ambassador/config/MetricsConfig.java#L40-L49

It also introduces a replacement for the auto-configured https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfiguration.html#errorAttributes--  which will augment the standard JSON response body with "app" and "host" fields.

For example:

```json
{
  "timestamp": "2019-06-06T21:53:03.433+0000",
  "status": 400,
  "error": "Bad Request",
  "errors": [
    {
      "codes": [
        "NotNull.createTask.taskParameters",
        "NotNull.taskParameters",
        "NotNull.com.rackspace.salus.event.manage.model.TaskParameters",
        "NotNull"
      ],
      "arguments": [
        {
          "codes": [
            "createTask.taskParameters",
            "taskParameters"
          ],
          "arguments": null,
          "defaultMessage": "taskParameters",
          "code": "taskParameters"
        }
      ],
      "defaultMessage": "must not be null",
      "objectName": "createTask",
      "field": "taskParameters",
      "rejectedValue": null,
      "bindingFailure": false,
      "code": "NotNull"
    }
  ],
  "message": "Validation failed for object='createTask'. Error count: 1",
  "path": "/api/tasks/aaaaaa",
  "app": "salus-event-engine-management",
  "host": "MS90HCG8WL"
}
```

## How to test

Manual verification so far

# TODO

I'll be replacing some (or all) of our `@ControllerAdvice` instances with something like

https://gist.github.com/itzg/ae402158e9952be2d45f78a6196e8f7f