### PR TITLE
Remove etcd details

### DIFF
--- a/src/main/java/com/rackspace/salus/common/workpart/config/EtcdConfig.java
+++ b/src/main/java/com/rackspace/salus/common/workpart/config/EtcdConfig.java
@@ -9,18 +9,6 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 @Configuration
 public class EtcdConfig {
 
-  private final EtcdProperties properties;
-
-  @Autowired
-  public EtcdConfig(EtcdProperties properties) {
-    this.properties = properties;
-  }
-
-  @Bean
-  public Client etcdClient() {
-    return Client.builder().endpoints(properties.getUrl()).build();
-  }
-
   @Bean
   public ThreadPoolTaskScheduler workAllocatorTaskScheduler() {
     final ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();


### PR DESCRIPTION
This logic does not need to be in `common` as it is already in `etcd-adapter`.  Any service that interacts with `etcd` will now use that service.

This just cleans up our dependencies a little bit.

Relates to https://github.com/racker/salus-telemetry-api/pull/39 and an upcoming presence monitor PR.