### PR TITLE
Update role based auth

### DIFF
--- a/src/main/java/com/rackspace/salus/common/web/PreAuthenticatedFilter.java
+++ b/src/main/java/com/rackspace/salus/common/web/PreAuthenticatedFilter.java
@@ -65,7 +65,6 @@ public class PreAuthenticatedFilter extends GenericFilterBean {
   }
 
   Optional<PreAuthenticatedToken> getToken(HttpServletRequest req) {
-
     final Set<String> rolesSet = new HashSet<>();
     for (String header : rolesHeaders) {
       List<String> roleValues = Arrays.asList(req.getHeader(header).split(","));
@@ -86,6 +85,7 @@ public class PreAuthenticatedFilter extends GenericFilterBean {
 
       return Optional.of(new PreAuthenticatedToken(tenant, roles));
     } else {
+      log.debug("Skipping PreAuthenticatedToken creation for tenant={}, roles={}", tenant, rolesSet);
       return Optional.empty();
     }
   }

--- a/src/main/java/com/rackspace/salus/common/web/PreAuthenticatedFilter.java
+++ b/src/main/java/com/rackspace/salus/common/web/PreAuthenticatedFilter.java
@@ -67,8 +67,11 @@ public class PreAuthenticatedFilter extends GenericFilterBean {
   Optional<PreAuthenticatedToken> getToken(HttpServletRequest req) {
     final Set<String> rolesSet = new HashSet<>();
     for (String header : rolesHeaders) {
-      List<String> roleValues = Arrays.asList(req.getHeader(header).split(","));
-      rolesSet.addAll(roleValues);
+      String roleString = req.getHeader(header);
+      if (roleString != null) {
+        List<String> roleValues = Arrays.asList(roleString.split(","));
+        rolesSet.addAll(roleValues);
+      }
     }
     final String tenant = req.getHeader(tenantHeader);
 

--- a/src/main/java/com/rackspace/salus/common/web/PreAuthenticatedFilter.java
+++ b/src/main/java/com/rackspace/salus/common/web/PreAuthenticatedFilter.java
@@ -55,7 +55,7 @@ public class PreAuthenticatedFilter extends GenericFilterBean {
                        FilterChain chain) throws IOException, ServletException {
     if (servletRequest instanceof HttpServletRequest) {
       final HttpServletRequest req = (HttpServletRequest) servletRequest;
-      if(getToken(req).isPresent()) {
+      if (getToken(req).isPresent()) {
         final PreAuthenticatedToken auth = getToken(req).get();
         log.debug("Processed Repose-driven authentication={}", auth);
         SecurityContextHolder.getContext().setAuthentication(auth);

--- a/src/main/java/com/rackspace/salus/common/web/PreAuthenticatedFilter.java
+++ b/src/main/java/com/rackspace/salus/common/web/PreAuthenticatedFilter.java
@@ -55,8 +55,9 @@ public class PreAuthenticatedFilter extends GenericFilterBean {
                        FilterChain chain) throws IOException, ServletException {
     if (servletRequest instanceof HttpServletRequest) {
       final HttpServletRequest req = (HttpServletRequest) servletRequest;
-      if (getToken(req).isPresent()) {
-        final PreAuthenticatedToken auth = getToken(req).get();
+      Optional<PreAuthenticatedToken> token = getToken(req);
+      if (token.isPresent()) {
+        final PreAuthenticatedToken auth = token.get();
         log.debug("Processed Repose-driven authentication={}", auth);
         SecurityContextHolder.getContext().setAuthentication(auth);
       }

--- a/src/main/java/com/rackspace/salus/common/web/PreAuthenticatedFilter.java
+++ b/src/main/java/com/rackspace/salus/common/web/PreAuthenticatedFilter.java
@@ -64,7 +64,7 @@ public class PreAuthenticatedFilter extends GenericFilterBean {
     chain.doFilter(servletRequest, servletResponse);
   }
 
-  public Optional<PreAuthenticatedToken> getToken(HttpServletRequest req) {
+  Optional<PreAuthenticatedToken> getToken(HttpServletRequest req) {
 
     final Set<String> rolesSet = new HashSet<>();
     for (String header : rolesHeaders) {

--- a/src/main/java/com/rackspace/salus/common/web/PreAuthenticatedFilter.java
+++ b/src/main/java/com/rackspace/salus/common/web/PreAuthenticatedFilter.java
@@ -54,8 +54,8 @@ public class PreAuthenticatedFilter extends GenericFilterBean {
     if (servletRequest instanceof HttpServletRequest) {
       final HttpServletRequest req = (HttpServletRequest) servletRequest;
 
-      final List<String> rolesList = rolesHeaders.stream().flatMap(header -> Stream.of(req.getHeader(header))).collect(
-          Collectors.toList());
+      final List<String> rolesList = rolesHeaders.stream().flatMap(header -> Stream.of(req.getHeader(header)))
+          .collect(Collectors.toList());
       final String tenant = req.getHeader(tenantHeader);
 
       if (!rolesList.isEmpty() && (StringUtils.hasText(tenant))) {

--- a/src/main/java/com/rackspace/salus/common/web/ReposeHeaderFilter.java
+++ b/src/main/java/com/rackspace/salus/common/web/ReposeHeaderFilter.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.common.web;
 
+import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -27,9 +28,10 @@ import lombok.extern.slf4j.Slf4j;
 public class ReposeHeaderFilter extends PreAuthenticatedFilter {
 
     public static final String HEADER_X_ROLES = "X-Roles";
+    public static final String HEADER_X_IMPERSONATOR_ROLES = "X-Impersonator-Roles";
     public static final String HEADER_TENANT = "X-Tenant-Id";
 
     public ReposeHeaderFilter() {
-        super(HEADER_TENANT, HEADER_X_ROLES);
+        super(HEADER_TENANT, Arrays.asList(HEADER_X_ROLES, HEADER_X_IMPERSONATOR_ROLES));
     }
 }

--- a/src/test/java/com/rackspace/salus/common/web/PreAuthenticatedFilterTest.java
+++ b/src/test/java/com/rackspace/salus/common/web/PreAuthenticatedFilterTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.common.web;
+
+import static com.rackspace.salus.common.web.ReposeHeaderFilter.HEADER_TENANT;
+import static com.rackspace.salus.common.web.ReposeHeaderFilter.HEADER_X_IMPERSONATOR_ROLES;
+import static com.rackspace.salus.common.web.ReposeHeaderFilter.HEADER_X_ROLES;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import org.hamcrest.core.StringStartsWith;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.core.GrantedAuthority;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PreAuthenticatedFilterTest {
+
+  @Mock
+  HttpServletRequest servletRequest;
+
+  @Test
+  public void testGetToken() {
+    PreAuthenticatedFilter preAuthenticatedFilter = new PreAuthenticatedFilter(HEADER_TENANT,
+        Arrays.asList(HEADER_X_ROLES, HEADER_X_IMPERSONATOR_ROLES));
+    String userRoles = "monitoring:admin,dedicated:default,ticketing:admin,identity:user-admin";
+    String impersonationRoles = "custom:my-admin,salus:admin";
+    String tenantId = "12345";
+
+    when(servletRequest.getHeader(HEADER_X_ROLES))
+        .thenReturn(userRoles);
+
+    when(servletRequest.getHeader(HEADER_X_IMPERSONATOR_ROLES))
+        .thenReturn(impersonationRoles);
+
+    when(servletRequest.getHeader(HEADER_TENANT))
+        .thenReturn(tenantId);
+
+    Optional<PreAuthenticatedToken> token = preAuthenticatedFilter.getToken(servletRequest);
+
+    assertTrue(token.isPresent());
+    assertThat(token.get().getAuthorities(), hasSize(6));
+    for (GrantedAuthority authority : token.get().getAuthorities()) {
+      assertThat(authority.getAuthority(), StringStartsWith.startsWith("ROLE_"));
+    }
+  }
+}


### PR DESCRIPTION
# What

Handles x-roles and x-impersonation-roles when using things like the repose header filter.

# How

Repose sends the headers down as a comma separated string in a single header.  It now reads these one value vs. trying to get a list of headers for each one.

I also updated it so it will look at impersonation roles in addition to user roles.

## How to test

Added a unit test
We'll test after deploying to be certain.

# Why

The original logic expected multiple headers to be found for x-roles vs. the one list.  It also didn't look at impersonation roles.  This should allow us to auth correctly to the public/admin apis and also the auth service.

```
Granted Authorities: ROLE_MONITORING_ADMIN,DEDICATED_DEFAULT,TICKETING_ADMIN,IDENTITY_USER_ADMIN
```
This is returning one single authority vs. many.  That is why it looks like only the first has "ROLE_" because it is treating the whole thing as one.
# TODO

PR incoming to update the auth service filter logic.