### PR TITLE
Update cloudbuild definitions

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -1,8 +1,52 @@
+substitutions:
+  _GCS_CACHE_BUCKET: salus-cache
+  _SALUS_PROJECT: salus-common
+
 steps:
-  - name: 'gcr.io/cloud-builders/gsutil'
-    id: GET_SETTINGS
+
+  # Pull down settings file for Artifactory settings
+  - id: GET_SETTINGS
+    name: 'gcr.io/cloud-builders/gsutil'
+    waitFor: ['-']
     args: ['cp', 'gs://salus-mavenrepository/m2-settings.xml', '.mvn/settings.xml']
-  - name: 'gcr.io/cloud-builders/mvn'
-    id: DEPLOY
-    args: ['deploy', '-s', '.mvn/settings.xml']
+
+  # Load the cached files from GCS if they exist.
+  - id: PULL_DOWN_CACHE
+    waitFor: ['-']
+    name: gcr.io/cloud-builders/gsutil
+    dir: /root
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        (
+          gsutil cp gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz /tmp/m2-cache.tar.gz &&
+          tar -xzf /tmp/m2-cache.tar.gz
+        ) || echo 'Cache not found'
+    volumes:
+      - name: user.home
+        path: /root
+
+  - id: DEPLOY
+    name: 'gcr.io/cloud-builders/mvn'
+    args: ['-B', 'deploy', '-s', '.mvn/settings.xml']
+    volumes:
+      - name: user.home
+        path: /root
+
+  # Saves the files to the GCS cache.
+  - id: PUSH_UP_CACHE
+    name: gcr.io/cloud-builders/gsutil
+    dir: /root
+    entrypoint: bash
+    # Caches the local Maven repository.
+    args:
+      - -c
+      - |
+        set -ex
+        tar -czf /tmp/m2-cache.tar.gz .m2 &&
+        gsutil cp /tmp/m2-cache.tar.gz gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz
+    volumes:
+      - name: user.home
+        path: /root
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,8 +1,52 @@
+substitutions:
+  _GCS_CACHE_BUCKET: salus-cache
+  _SALUS_PROJECT: salus-common
+
 steps:
-  - name: 'gcr.io/cloud-builders/gsutil'
-    id: GET_SETTINGS
+
+  # Pull down settings file for Artifactory settings
+  - id: GET_SETTINGS
+    name: 'gcr.io/cloud-builders/gsutil'
+    waitFor: ['-']
     args: ['cp', 'gs://salus-mavenrepository/m2-settings.xml', '.mvn/settings.xml']
-  - name: 'gcr.io/cloud-builders/mvn'
-    id: VERIFY
-    args: ['verify', '-s', '.mvn/settings.xml']
+
+  # Load the cached files from GCS if they exist.
+  - id: PULL_DOWN_CACHE
+    waitFor: ['-']
+    name: gcr.io/cloud-builders/gsutil
+    dir: /root
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        (
+          gsutil cp gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz /tmp/m2-cache.tar.gz &&
+          tar -xzf /tmp/m2-cache.tar.gz
+        ) || echo 'Cache not found'
+    volumes:
+      - name: user.home
+        path: /root
+
+  - id: VERIFY
+    name: 'gcr.io/cloud-builders/mvn'
+    args: ['-B', 'verify', '-s', '.mvn/settings.xml']
+    volumes:
+      - name: user.home
+        path: /root
+
+  # Saves the files to the GCS cache.
+  - id: PUSH_UP_CACHE
+    name: gcr.io/cloud-builders/gsutil
+    dir: /root
+    entrypoint: bash
+    # Caches the local Maven repository.
+    args:
+      - -c
+      - |
+        set -ex
+        tar -czf /tmp/m2-cache.tar.gz .m2 &&
+        gsutil cp /tmp/m2-cache.tar.gz gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz
+    volumes:
+      - name: user.home
+        path: /root
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.github.mxsm</groupId>
       <artifactId>jetcd-launcher</artifactId>
-      <version>0.3.6</version>
+      <version>0.3.7</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
# What

While watching the builds for the Java 11 upgrade I noticed this one still had the old cloudbuild definitions that were missing repo caching and the quieter maven logging.

# How

Copied over one the recent cloudbuild definitions and adjust the project name.