### PR TITLE
Add descriptor of salus.environment

### DIFF
--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,20 @@
+{
+  "properties": [{
+    "name": "salus.environment",
+    "description": "Deployment environment designation that is used to differentiate application instances.",
+    "defaultValue": "local",
+    "type": "java.lang.String"
+  }],
+  "hints": [{
+    "name": "salus.environment",
+    "values": [{
+      "value": "local"
+    },{
+      "value": "dev"
+    }, {
+      "value": "staging"
+    }, {
+      "value": "prod"
+    }]
+  }]
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-544

# What

Since there's not yet a UMB instance per cluster/environment (dev, staging, prod), then we need to differentiate our kafka consumer group declarations to avoid application instances from multiple clusters all joining the same consumer group.

# How

In this particular library we just pre-declare the property using [this mechanism](https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html#configuration-metadata-additional-metadata). Each of the applications that will make use of this will need to declare the following default since Spring Boot doesn't seem to be actually using that `defaultValue` across apps:

```yaml
salus:
  environment: local
```

Here is an example of how this property in turn will be used to qualify our kafka consumer group declarations:

```yaml
spring:
  kafka:
    producer:
      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
    consumer:
      group-id: ${spring.application.name}-${salus.environment}
```

# TODO

Update any of our `application.yml`'s that use `spring.kafka.consumer.group-id`

# Related to

https://github.com/Rackspace-Segment-Support/helm-salus-ambassador/pull/27