### PR TITLE
Add an "enable" annotation for ExtendedErrorAttributes

### DIFF
--- a/src/main/java/com/rackspace/salus/common/web/EnableExtendedErrorAttributes.java
+++ b/src/main/java/com/rackspace/salus/common/web/EnableExtendedErrorAttributes.java
@@ -1,0 +1,31 @@
+package com.rackspace.salus.common.web;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.context.annotation.Import;
+
+/**
+ * When enabled on an application's {@link org.springframework.context.annotation.Configuration} bean,
+ * this will register an {@link ErrorAttributes} bean that augments the standard response content with:
+ * <ul>
+ *   <li><code>app</code> : the value of the <code>spring.application.name</code> property</li>
+ *   <li><code>host</code> : the value of the <code>localhost.name</code> property</li>
+ * </ul>
+ * <p>
+ *   <em>NOTE:</em> this requires <code>spring.application.name</code> to be configured in
+ *   <code>application.yml</code> (or similar), which is why this needs to be explicitly enabled.
+ * </p>
+ * @see com.rackspace.salus.common.env.LocalhostPropertySourceProcessor
+ * @see ExtendedErrorAttributesConfig
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(ExtendedErrorAttributesConfig.class)
+public @interface EnableExtendedErrorAttributes {
+
+}

--- a/src/main/java/com/rackspace/salus/common/web/ExtendedErrorAttributesConfig.java
+++ b/src/main/java/com/rackspace/salus/common/web/ExtendedErrorAttributesConfig.java
@@ -38,6 +38,10 @@ import org.springframework.web.context.request.WebRequest;
  *   <code>application.yml</code> (or similar), which is why this configuration bean needs
  *   to be opted in with an <code>&#64;Import</code>.
  * </p>
+ * <p>
+ *   It is recommended for readability to just use {@link EnableExtendedErrorAttributes} instead of
+ *   directly {@link org.springframework.context.annotation.Import}ing this.
+ * </p>
  * @see com.rackspace.salus.common.env.LocalhostPropertySourceProcessor
  */
 @Configuration


### PR DESCRIPTION
# What

Seeing this

https://github.com/racker/salus-policy-management/pull/1/files#diff-6c05132d25a2c200983a35bf570c8cb3R28

made me realize that I should have declared an "enable" annotation when adding the config bean. Then it keeps are opt-in feature enabling consistently readable.

# How

Add a class-level annotation that `Import`s the config bean.