### PR TITLE
Upgrading to Spring Boot 2.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>11</java.version>
     <jetcd.version>0.3.0</jetcd.version>
+    <protobuf.version>3.9.0</protobuf.version>
   </properties>
 
   <dependencies>
@@ -19,6 +20,11 @@
       <groupId>io.etcd</groupId>
       <artifactId>jetcd-core</artifactId>
       <version>${jetcd.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -54,10 +60,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.21.0</version>
         <configuration>
@@ -84,7 +86,7 @@
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.1.2.RELEASE</version>
+        <version>2.1.6.RELEASE</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-361

# What

Our library and apps were on Spring Boot 2.1.2, but it's always good to stay on top of the latest release, which is 2.1.6.

## How to test

Unit tests and manual application startup.