### PR TITLE
added a utility class to be able to read in java resource files as a String

### DIFF
--- a/src/main/java/com/rackspace/salus/common/util/ResourceUtils.java
+++ b/src/main/java/com/rackspace/salus/common/util/ResourceUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.common.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.FileCopyUtils;
+
+public class ResourceUtils {
+
+  public static String readContent(String resource) throws IOException {
+    try (InputStream in = new ClassPathResource(resource).getInputStream()) {
+      return FileCopyUtils.copyToString(new InputStreamReader(in));
+    }
+  }
+}
+

--- a/src/main/java/com/rackspace/salus/common/util/SpringResourceUtils.java
+++ b/src/main/java/com/rackspace/salus/common/util/SpringResourceUtils.java
@@ -22,7 +22,7 @@ import java.io.InputStreamReader;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.util.FileCopyUtils;
 
-public class ResourceUtils {
+public class SpringResourceUtils {
 
   public static String readContent(String resource) throws IOException {
     try (InputStream in = new ClassPathResource(resource).getInputStream()) {


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-480

# What

This is just creating  a utility function in a common location so that we can read in the SQL templates

# Why

We were already using this in testing to load in resource files as String's so I figured why not just use it to load up the SQL files as well.
