### PR TITLE
Provide better handling of exceptions thrown by RestTemplate

### DIFF
--- a/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
@@ -16,20 +16,32 @@
 
 package com.rackspace.salus.common.web;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.rackspace.salus.common.errors.ResponseMessages;
+import com.rackspace.salus.common.errors.RuntimeKafkaException;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.context.request.ServletWebRequest;
 
 /**
  * This handler can be used as a base class for
  * {@link org.springframework.web.bind.annotation.ControllerAdvice} with
  * {@link org.springframework.web.bind.annotation.ExceptionHandler}'s to generalize the
- * formatting of a JSON error resposne body that aligns with the standard Spring Boot
+ * formatting of a JSON error response body that aligns with the standard Spring Boot
  * error controller.
+ * <p>
+ *   Handlers are provided for common cases, such as handling {@link IllegalArgumentException}
+ *   and {@link IllegalArgumentException}.
+ * </p>
  * <p>
  *   The following shows an example of implementing controller advice with this base class:
  * </p>
@@ -44,14 +56,16 @@ import org.springframework.web.context.request.ServletWebRequest;
      super(errorAttributes);
    }
 
-   &#64;ExceptionHandler({IllegalArgumentException.class})
-   public ResponseEntity<?> handleBadRequest(HttpServletRequest request) {
+   &#64;ExceptionHandler({CustomAppException.class})
+   public ResponseEntity<?> handleCustomAppException(HttpServletRequest request, Exception e) {
+     logRequestFailure(request, e);
      return respondWith(request, HttpStatus.BAD_REQUEST);
    }
    ...
 
   * </pre>
  */
+@Slf4j
 public abstract class AbstractRestExceptionHandler {
 
   private final ErrorAttributes errorAttributes;
@@ -86,8 +100,75 @@ public abstract class AbstractRestExceptionHandler {
     return new ResponseEntity<>(body, status);
   }
 
+  /**
+   * Provides a uniform logging strategy for exception handlers.
+   * @param request the request that was being handled
+   * @param e the {@link Exception} that was thrown while handling the request
+   */
+  protected void logRequestFailure(HttpServletRequest request, Exception e) {
+    log.warn("Web request for uri={} failed", request.getRequestURI(), e);
+  }
+
   private Map<String, Object> getErrorAttributes(HttpServletRequest request) {
     final ServletWebRequest webRequest = new ServletWebRequest(request);
     return errorAttributes.getErrorAttributes(webRequest, false);
   }
+
+  @ExceptionHandler({IllegalArgumentException.class})
+  public ResponseEntity<?> handleBadRequest(HttpServletRequest request, Exception e) {
+
+    logRequestFailure(request, e);
+    return respondWith(request, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler({RemoteServiceCallException.class})
+  public ResponseEntity<?> handleRemoteServiceCallException(
+      HttpServletRequest request, RemoteServiceCallException e) {
+
+    logRequestFailure(request, e);
+    return respondWith(request, e.getStatusCode(), e.getMessage());
+  }
+
+  @ExceptionHandler({IllegalStateException.class})
+  public ResponseEntity<?> handleBadState(HttpServletRequest request, Exception e) {
+
+    logRequestFailure(request, e);
+    return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler({RestClientException.class})
+  public ResponseEntity<?> handleRestClientException(HttpServletRequest request, RestClientException e) {
+    logRequestFailure(request, e);
+
+    if (e instanceof HttpStatusCodeException) {
+      return respondWith(request, ((HttpStatusCodeException) e).getStatusCode(), "Remote REST exchange failed");
+    }
+    else {
+      return respondWith(request, HttpStatus.BAD_GATEWAY, e.getMessage());
+    }
+  }
+
+  @ExceptionHandler({HttpMessageNotReadableException.class})
+  public ResponseEntity<?> handleHttpMessageNotReadable(HttpServletRequest request,
+                                                        HttpMessageNotReadableException e) {
+    logRequestFailure(request, e);
+
+    if (e.getCause() instanceof JsonMappingException) {
+      final JsonMappingException jsonMappingException = (JsonMappingException) e.getCause();
+
+      return respondWith(request, HttpStatus.BAD_REQUEST,
+          String.format("Failed to parse JSON at %s", jsonMappingException.getPathReference()));
+    }
+    else {
+      // fallback to default message derivation
+      return respondWith(request, HttpStatus.BAD_REQUEST);
+    }
+  }
+
+  @ExceptionHandler({RuntimeKafkaException.class})
+  public ResponseEntity<?> handleKafkaExceptions(HttpServletRequest request, Exception e) {
+    logRequestFailure(request, e);
+    return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.kafkaExceptionMessage);
+  }
+
 }

--- a/src/main/java/com/rackspace/salus/common/web/RemoteOperations.java
+++ b/src/main/java/com/rackspace/salus/common/web/RemoteOperations.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.common.web;
+
+import java.util.function.Supplier;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Provides utilities for remote service call operations.
+ */
+public class RemoteOperations {
+
+  /**
+   * Wraps a use of {@link RestTemplate} with standardized exception handling of
+   * {@link IllegalArgumentException} and {@link RestClientException}.
+   * <p>
+   *   The following shows an example of wrapping a typical use of RestTemplate:
+   *   <pre>
+   return mapRestClientExceptions(
+     "policy-management",
+     () ->
+       restTemplate.exchange(
+         uri,
+         HttpMethod.GET,
+         null,
+         MAP_OF_MONITOR_POLICY
+       ).getBody()
+   );
+   *   </pre>
+   * </p>
+   * @param remoteServiceName the name of the remote service being called
+   * @param wrapped the code making use of {@link RestTemplate}
+   * @param <R> the return type of the wrapped supplier
+   * @return the value returned by the wrapped supplier
+   */
+  public static <R> R mapRestClientExceptions(String remoteServiceName, Supplier<R> wrapped) {
+    try {
+
+      return wrapped.get();
+
+    } catch (IllegalArgumentException e) {
+      throw new IllegalStateException(
+          String.format("REST exchange with %s was malformed", remoteServiceName), e);
+    } catch (RestClientException e) {
+      throw new RemoteServiceCallException(remoteServiceName, e);
+    }
+  }
+
+}

--- a/src/main/java/com/rackspace/salus/common/web/RemoteServiceCallException.java
+++ b/src/main/java/com/rackspace/salus/common/web/RemoteServiceCallException.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.common.web;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Indicates that a remote inter-service call, typically via REST, has failed. There is a companion
+ * handler in {@link AbstractRestExceptionHandler} that will intercept this exception type.
+ */
+public class RemoteServiceCallException extends RuntimeException {
+
+  private final String remoteServiceName;
+
+  /**
+   * When a {@link RestClientException} is caught from an invocation of a {@link RestTemplate}
+   * method, then this constructor can wrap that cause with further details about the attempted
+   * service interaction.
+   * @param remoteServiceName the name of the remote service
+   * @param cause the {@link RestClientException} thrown by a {@link RestTemplate} call
+   */
+  public RemoteServiceCallException(String remoteServiceName, RestClientException cause) {
+    super(String.format("Remote call to service %s failed", remoteServiceName), cause);
+    this.remoteServiceName = remoteServiceName;
+  }
+
+  public String getRemoteServiceName() {
+    return remoteServiceName;
+  }
+
+  public HttpStatus getStatusCode() {
+    if (getCause() instanceof HttpStatusCodeException) {
+      return ((HttpStatusCodeException) getCause()).getStatusCode();
+    }
+    else {
+      return HttpStatus.BAD_GATEWAY;
+    }
+  }
+}

--- a/src/test/java/com/rackspace/salus/common/web/RemoteOperationsTest.java
+++ b/src/test/java/com/rackspace/salus/common/web/RemoteOperationsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.common.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
+
+public class RemoteOperationsTest {
+
+  @Test
+  public void testMapRestClientExceptions_returnValue() {
+    final String result = RemoteOperations.mapRestClientExceptions("some-service", () -> {
+      return "resulting value";
+    });
+
+    assertThat(result).isEqualTo("resulting value");
+  }
+
+  @Test
+  public void testMapRestClientExceptions_illegalArg() {
+
+    assertThatThrownBy(() -> {
+      RemoteOperations.mapRestClientExceptions("some-service", () -> {
+        throw new IllegalArgumentException("just a test");
+      });
+
+    })
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("some-service");
+  }
+
+  @Test
+  public void testMapRestClientExceptions_httpStatusError() {
+    assertThatThrownBy(() -> {
+      RemoteOperations.mapRestClientExceptions("some-service", () -> {
+        throw HttpClientErrorException
+            .create(HttpStatus.BAD_REQUEST, "bad request", HttpHeaders.EMPTY, null, null);
+      });
+
+    })
+        .isInstanceOf(RemoteServiceCallException.class)
+        .hasMessageContaining("some-service")
+        .hasCauseInstanceOf(RestClientException.class)
+        .extracting("remoteServiceName", "statusCode")
+        .containsExactly("some-service", HttpStatus.BAD_REQUEST);
+  }
+
+  @Test
+  public void testMapRestClientExceptions_generalClientError() {
+    assertThatThrownBy(() -> {
+      RemoteOperations.mapRestClientExceptions("some-service", () -> {
+        throw new RestClientException("mystery exception");
+      });
+
+    })
+        .isInstanceOf(RemoteServiceCallException.class)
+        .hasMessageContaining("some-service")
+        .hasCauseInstanceOf(RestClientException.class)
+        .extracting("remoteServiceName", "statusCode")
+        .containsExactly("some-service", HttpStatus.BAD_GATEWAY);
+  }
+}


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-634

# What

When monitor management is missing one of the `salus.services` properties, the `RestTemplate` call throws an `IllegalArgumentException` with very little information. In turn, the response to the original monitor management call, such as when creating a monitor, has a status code of 400 and a body of

```json
{
"timestamp": "2019-09-30T18:30:43.792+0000",
"status": 400,
"error": "Bad Request",
"message": "URI is not absolute",
"app": "salus-telemetry-monitor-management",
"host": "monitor-management-5f7db89967-cj54d"
}
```

The logs contain no indication of what originally induced the "URI is not absolute" -- I was only able to narrow this one down to a `RestTemplate` call because I know we do the `RestTemplateBuilder` stuff in our client components.

In a production system this would be hard to debug because:
- the status code didn't even indicate this was a system misconfiguration
- the message was way too vague
- the application logs give no clues at all

On the last bullet, the only logging at debug level is:

```
08:48:04.761 [http-nio-8089-exec-1] DEBUG o.s.w.s.m.m.a.ExceptionHandlerExceptionResolver#144 Resolved [java.lang.IllegalArgumentException: URI is not absolute]
08:48:04.762 [http-nio-8089-exec-1] DEBUG o.s.w.s.DispatcherServlet#1130 Completed 400 BAD_REQUEST
```

# How

I ended up bundling a few inter-related changes into this:
- added `RemoteOperations` with a helper method that takes a lambda (supplier) and catches the two types of exceptions commonly thrown by `RestTemplate`
- added `RemoteServiceCallException` to wrap the `RestClientException`s thrown by `RestTemplate` with the name of our service being called
- I discovered that `@ExceptionHandler` methods in `AbstractRestExceptionHandler` do get picked up by Spring MVC in our apps, so that means we can refactor common exception handling into this abstract handler
- Added a `logRequestFailure` method in the abstract handler that can be used to log the failed requests in a standard way from within our exception handler classes

# How to test

Added a unit test for `RemoteOperations` since it does some specific mapping of exceptions and status codes.

# TODO

I'll create follow-up PRs to make use of the new rest client wrapper and refactored handler methods. I'll probably just start with monitor and policy management since that was where I first spotted the issue.