### PR TITLE
Declared shared fluency config that uses application name in tag

### DIFF
--- a/src/main/resources/logback-fluency.xml
+++ b/src/main/resources/logback-fluency.xml
@@ -1,0 +1,55 @@
+<!--
+  ~ Copyright 2019 Rackspace US, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<included>
+  <springProperty scope="context" name="SALUS_FLUENTD_HOST" source="salus.fluentd.host"
+    defaultValue="localhost"/>
+  <springProperty scope="context" name="SALUS_FLUENTD_PORT" source="salus.fluentd.port"
+    defaultValue="24224"/>
+  <springProperty scope="context" name="SALUS_FLUENTD_QUEUESIZE" source="salus.fluentd.queue-size"
+    defaultValue="999"/>
+  <springProperty scope="context" name="SALUS_FLUENTD_NEVERBLOCK" source="salus.fluentd.never-block"
+    defaultValue="true"/>
+
+  <springProperty scope="context" name="SALUS_FLUENTD_MAXFLUSHTIME" source="salus.fluentd.max-flush-time"
+    defaultValue="10000"/>
+
+  <appender name="FLUENCY_SYNC" class="ch.qos.logback.more.appenders.FluencyLogbackAppender">
+    <tag>salus</tag>
+
+    <!-- Host name/address and port number which Flentd placed -->
+    <remoteHost>${SALUS_FLUENTD_HOST}</remoteHost>
+    <port>${SALUS_FLUENTD_PORT}</port>
+
+    <encoder>
+      <pattern><![CDATA[%date{HH:mm:ss.SSS} [%thread] %-5level %logger{15}#%line %msg]]></pattern>
+    </encoder>
+  </appender>
+
+  <appender name="FLUENCY" class="ch.qos.logback.classic.AsyncAppender">
+    <!-- Max queue size of logs which is waiting to be sent (When it reach to the max size, the log will be disappeared). -->
+    <queueSize>${SALUS_FLUENTD_QUEUESIZE}</queueSize>
+    <!-- Never block when the queue becomes full. -->
+    <neverBlock>${SALUS_FLUENTD_NEVERBLOCK}</neverBlock>
+    <!-- The default maximum queue flush time allowed during appender stop.
+         If the worker takes longer than this time it will exit, discarding any remaining items in the queue.
+         10000 millis
+     -->
+    <maxFlushTime>${SALUS_FLUENTD_MAXFLUSHTIME}</maxFlushTime>
+    <appender-ref ref="FLUENCY_SYNC" />
+  </appender>
+
+</included>

--- a/src/main/resources/logback-fluency.xml
+++ b/src/main/resources/logback-fluency.xml
@@ -15,6 +15,7 @@
   -->
 
 <included>
+  <springProperty scope="context" name="SPRING_APPLICATION_NAME" source="spring.application.name"/>
   <springProperty scope="context" name="SALUS_FLUENTD_HOST" source="salus.fluentd.host"
     defaultValue="localhost"/>
   <springProperty scope="context" name="SALUS_FLUENTD_PORT" source="salus.fluentd.port"
@@ -28,14 +29,14 @@
     defaultValue="10000"/>
 
   <appender name="FLUENCY_SYNC" class="ch.qos.logback.more.appenders.FluencyLogbackAppender">
-    <tag>salus</tag>
+    <tag>application.${SPRING_APPLICATION_NAME}</tag>
 
     <!-- Host name/address and port number which Flentd placed -->
     <remoteHost>${SALUS_FLUENTD_HOST}</remoteHost>
     <port>${SALUS_FLUENTD_PORT}</port>
 
     <encoder>
-      <pattern><![CDATA[%date{HH:mm:ss.SSS} [%thread] %-5level %logger{15}#%line %msg]]></pattern>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
# Resolves

Related to https://jira.rax.io/browse/SALUS-653

# What

I discovered that inclusions from within `logback-spring.xml` can access a config file situated in `salus-common`, so now we can make app wide changes in one spot and avoid a duplicated file.

# How

...I also enhanced the fluentd tag to include the `spring.application.name` property so that fluentd configs can match on that tag more precisely and we can convey the app name into the final ES stored log documents, such as

```json
{
    "level": "INFO",
    "logger": "org.springframework.security.web.DefaultSecurityFilterChain",
    "thread": "main",
    "message": "Creating filter chain: any request, ...",
    "@timestamp": "2019-10-23T21:21:25.000000000+00:00",
    "tag": "application.salus-api-public"
  }
```

# How to test

Manually

# TODO

Remove `logback-fluency.xml` from our applications after checking each that it depends on `salus-common`.