### PR TITLE
Provide common registration for Kafka deserialization error handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,15 @@
       <artifactId>guava</artifactId>
       <version>27.0.1-jre</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka</artifactId>
+      <!--
+      Marked optional to ensure non-kafka apps aren't forced to include this transitively.
+      Applications that use EnableSalusKafkaMessaging must declare a spring-kafka dependency.
+      -->
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/src/main/java/com/rackspace/salus/common/messaging/EnableSalusKafkaMessaging.java
+++ b/src/main/java/com/rackspace/salus/common/messaging/EnableSalusKafkaMessaging.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.common.messaging;
 
 import java.lang.annotation.ElementType;
@@ -5,6 +21,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Import;
 
 /**
  * This annotation can be applied to a Spring Boot application class or any other {@link org.springframework.context.annotation.Configuration}
@@ -13,6 +30,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @EnableConfigurationProperties(KafkaTopicProperties.class)
+@Import(KafkaErrorConfig.class)
 public @interface EnableSalusKafkaMessaging {
 
 }

--- a/src/main/java/com/rackspace/salus/common/messaging/KafkaErrorConfig.java
+++ b/src/main/java/com/rackspace/salus/common/messaging/KafkaErrorConfig.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.common.messaging;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
+import org.springframework.boot.autoconfigure.kafka.ConcurrentKafkaListenerContainerFactoryConfigurer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.listener.ConsumerAwareErrorHandler;
+import org.springframework.kafka.support.serializer.DeserializationException;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
+
+@Configuration
+@Slf4j
+public class KafkaErrorConfig {
+
+  /**
+   * Gets picked up by Spring Boot Kafka autoconfig and registered with the default.
+   * This handler provides additional debug logging when {@link ErrorHandlingDeserializer2} is
+   * configured as the value deserializer since the original cause and payload can be extracted
+   * from the header set by that deserializer.
+   * {@link ConcurrentKafkaListenerContainerFactoryConfigurer} bean.
+   */
+  @Bean
+  public ConsumerAwareErrorHandler listenerContainerErrorHandler() {
+    return (e, data, consumer) -> {
+      final TopicPartition topicPartition = new TopicPartition(data.topic(), data.partition());
+      log.warn("Handling listener container error by skipping offset={} in={}", data.offset(), topicPartition, e);
+      consumer.seek(topicPartition, data.offset()+1);
+
+      if (log.isDebugEnabled()) {
+
+        final Iterable<Header> headerValues = data.headers()
+            .headers(ErrorHandlingDeserializer2.VALUE_DESERIALIZER_EXCEPTION_HEADER);
+        // headerValues will be empty if the exception header isn't present, so extra logging is skipped
+        for (Header headerValue : headerValues) {
+          try {
+            final ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(headerValue.value()));
+            final Object exceptionObj = ois.readObject();
+            if (exceptionObj instanceof DeserializationException) {
+
+              final DeserializationException deserEx = (DeserializationException) exceptionObj;
+              log.debug("Deserialization failed at offset={} in={} with raw data='{}'",
+                  data.offset(), topicPartition, new String(deserEx.getData(), StandardCharsets.UTF_8));
+
+            } else {
+              log.debug("Deserializer exception was unexpected type: {}", exceptionObj);
+            }
+          } catch (IOException | ClassNotFoundException ex) {
+            log.debug("Unable to build or read from ObjectInputStream for inspecting deserializer exception", ex);
+          }
+        }
+
+      }
+    };
+  }
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-668

# What

Exceptions thrown within kafka deserializers are processed within the lower layers of Spring Kafka, so the `@KafkaListener` method never gets called and the consumer never moves beyond any malformed messages in the metrics topic.

# How

By stitching together some documentation, poking around in Spring Boot code, and an SO answer I found how to register an error handler that can skip bad messages and optionally log the content and cause of the bad message:

- https://docs.spring.io/spring-kafka/reference/html/#error-handling-deserializer
- https://docs.spring.io/spring-kafka/reference/html/#container-error-handlers
- https://github.com/spring-projects/spring-boot/blob/2.1.x/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaAnnotationDrivenConfiguration.java#L70-L81
- https://stackoverflow.com/questions/51136942/how-to-handle-serializationexception-after-deserialization

## How to test

Applications will need to include a unit test as needed, such as https://github.com/racker/salus-event-engine-ingest/pull/15