### PR TITLE
Add local hostname as a fluentd field for pod identification

### DIFF
--- a/src/main/resources/logback-fluency.xml
+++ b/src/main/resources/logback-fluency.xml
@@ -16,6 +16,7 @@
 
 <included>
   <springProperty scope="context" name="SPRING_APPLICATION_NAME" source="spring.application.name"/>
+  <springProperty scope="context" name="OUR_HOSTNAME" source="localhost.name"/>
   <springProperty scope="context" name="SALUS_FLUENTD_HOST" source="salus.fluentd.host"
     defaultValue="localhost"/>
   <springProperty scope="context" name="SALUS_FLUENTD_PORT" source="salus.fluentd.port"
@@ -34,6 +35,11 @@
     <!-- Host name/address and port number which Flentd placed -->
     <remoteHost>${SALUS_FLUENTD_HOST}</remoteHost>
     <port>${SALUS_FLUENTD_PORT}</port>
+
+    <additionalField>
+      <key>host</key>
+      <value>${OUR_HOSTNAME}</value>
+    </additionalField>
 
     <encoder>
       <pattern>${FILE_LOG_PATTERN}</pattern>


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-715

# What

I noticed our logs in kibana were missing an identification of the pod, which is available via its hostname.

# How

Leverage the properties created by `LocalhostPropertySourceProcessor` to pick off and include the local hostname as a field of the logback payload.

# How to test

Used the fluentd service in our infra docker compose definitions.