### PR TITLE
Provide a web mvc interceptor that logs requests with the response status

### DIFF
--- a/src/main/java/com/rackspace/salus/common/web/RequestLogging.java
+++ b/src/main/java/com/rackspace/salus/common/web/RequestLogging.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.common.web;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+/**
+ * An interceptor that can be registered by a {@link WebMvcConfigurer} config bean via
+ * {@link WebMvcConfigurer#addInterceptors(InterceptorRegistry)}. It will log a summary of
+ * a request and its response to allow for easily locating within logs along with any trace IDs.
+ */
+@Slf4j
+public class RequestLogging extends HandlerInterceptorAdapter {
+
+  @Override
+  public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
+                              Object handler, Exception ex) throws Exception {
+    log.info("Request completed: method={} path={}{} parameters={} status={}",
+        request.getMethod(), request.getContextPath(), request.getServletPath(), request.getParameterMap(),
+        response.getStatus());
+  }
+
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-725

# What

We didn't have any existing log entries that included the request info, the response status, and the sleuth trace ID all together. As a result, it would have been hard to troubleshoot a specific request reported by one of our users and then pick out the logs associated with that trace.

# How

Based on [this article](https://www.baeldung.com/spring-http-logging), implemented a web mvc interceptor that will get registered by api-public and api-admin. It produces logs that look like:

```
2019-12-13 15:33:28.748  INFO [salus-api-public,da9caf57b709d1f7,da9caf57b709d1f7,true] 28541 --- [qtp284427775-36] c.r.salus.common.web.RequestLogging      : Request completed: method=GET path=/v1.0/tenant/aaaaaa/monitors parameters={} status=502

2019-12-13 15:34:46.722  INFO [salus-api-public,78ba9855342f098c,78ba9855342f098c,true] 28541 --- [qtp284427775-32] c.r.salus.common.web.RequestLogging      : Request completed: method=GET path=/v1.0/tenant/aaaaaa/resources parameters={page=[0]} status=200
```

# How to test

Manually via the api-public/api-admin applications