### PR TITLE
Removed the events topics, which was only used by presence monitor

### DIFF
--- a/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
+++ b/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,9 +32,6 @@ public class KafkaTopicProperties {
 
   @NotEmpty
   String metrics = "telemetry.metrics.json";
-
-  @NotEmpty
-  String events = "telemetry.events.json";
 
   @NotEmpty
   String attaches = "telemetry.attaches.json";


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-666

# What

Related to https://github.com/racker/salus-telemetry-presence-monitor/pull/46 this removes the events topic property that was only used by presence monitor.

# How

Remove the topic property.