### PR TITLE
Added Sleuth traceId, when available, to error response entity

### DIFF
--- a/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,6 +92,12 @@ public abstract class AbstractRestExceptionHandler {
       HttpServletRequest request,
       HttpStatus status, @Nullable String message) {
     Map<String, Object> body = getErrorAttributes(request);
+    // extract Spring Cloud Sleuth (aka Brave)'s traceId from incoming request headers to avoid
+    // pulling dependency into common module
+    final String traceId = request.getHeader("x-b3-traceid");
+    if (traceId != null) {
+      body.put("traceId", traceId);
+    }
     body.put("status", status.value());
     body.put("error", status.getReasonPhrase());
     if (message != null) {

--- a/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
@@ -68,6 +68,8 @@ import org.springframework.web.context.request.ServletWebRequest;
 @Slf4j
 public abstract class AbstractRestExceptionHandler {
 
+  private static final String SLEUTH_BRAVE_TRACE_ID_HEADER = "x-b3-traceid";
+
   private final ErrorAttributes errorAttributes;
 
   public AbstractRestExceptionHandler(
@@ -94,7 +96,7 @@ public abstract class AbstractRestExceptionHandler {
     Map<String, Object> body = getErrorAttributes(request);
     // extract Spring Cloud Sleuth (aka Brave)'s traceId from incoming request headers to avoid
     // pulling dependency into common module
-    final String traceId = request.getHeader("x-b3-traceid");
+    final String traceId = request.getHeader(SLEUTH_BRAVE_TRACE_ID_HEADER);
     if (traceId != null) {
       body.put("traceId", traceId);
     }


### PR DESCRIPTION
# What

The Spring Cloud Sleuth traceId gets included in the response header `X-Trace-Id`; however, that doesn't help when only the body of a failed REST response is logged. Likewise, I am guessing users may only provide the response body and not the headers when reporting an API issue to us.

# How

Leverage the request header that Sleuth/Brave adds to requests headers going through api admin/public and include that, when available, as a field in the error response body. Here is an example of one after this change:

```json
{
  "timestamp": "2020-01-16T20:27:17.254+0000",
  "status": 400,
  "error": "Bad Request",
  "message": "could not execute statement; SQL [n/a]; constraint [null]; nested exception is org.hibernate.exception.ConstraintViolationException: could not execute statement",
  "app": "salus-telemetry-monitor-management",
  "host": "MS90HCG8WL",
  "traceId": "ce34cb4c78d7ebeb"
}
```

# How to test

Locally via the admin-api with an operation that is known to fail in the backend service, such as a constraint violation.