### PR TITLE
Bumped Spring Boot version to 2.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2019 Rackspace US, Inc.
+  ~ Copyright 2020 Rackspace US, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.1.8.RELEASE</version>
+        <version>2.2.4.RELEASE</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-738

# What

Bumped Spring Boot version to 2.2.4. No other changes (like the h2->mysql DB stuff) were needed in this module.