### PR TITLE
Provided shared logback console config with console appender always registered

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2019 Rackspace US, Inc.
+  ~ Copyright 2020 Rackspace US, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -25,11 +25,9 @@
   </springProfile>
 
   <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
     <springProfile name="production">
       <appender-ref ref="FLUENCY" />
-    </springProfile>
-    <springProfile name="!production">
-      <appender-ref ref="CONSOLE"/>
     </springProfile>
   </root>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Rackspace US, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+
+<configuration>
+
+  <include resource="org/springframework/boot/logging/logback/defaults.xml" />
+  <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
+  <springProfile name="production">
+    <include resource="logback-fluency.xml" />
+  </springProfile>
+
+  <root level="INFO">
+    <springProfile name="production">
+      <appender-ref ref="FLUENCY" />
+    </springProfile>
+    <springProfile name="!production">
+      <appender-ref ref="CONSOLE"/>
+    </springProfile>
+  </root>
+
+</configuration>


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-770

# What

- When devops encounters fluentd configuration issues, the logging silently disappears when "production" profile is activated
- I had originally thought the file `logback-spring.xml` couldn't be picked by applications via a library jar in the classpath...I tested the theory and confirmed they actually can

# How

Provide a single, shared copy of `logback-spring.xml` that will allow (in follow PRs) application to no longer need to copy-paste the same file.

This specific change https://github.com/racker/salus-common/commit/7f786c148ee5d52ca20aa862860620c107817a60 shifts the CONSOLE appender out of a profile-conditional and registers it regardless of activate profile(s).

# How to test

I have verified locally by removing `logback-spring.xml` from an application and confirming the fluency appender is enabled with "production" profile is activated.