### PR TITLE
Added a common MetricsConfig and auto-config annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,18 @@
       -->
       <optional>true</optional>
     </dependency>
+    <!-- for metrics config support -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+      <optional>true</optional>
+    </dependency>
+
 
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/src/main/java/com/rackspace/salus/common/config/AutoConfigureSalusAppMetrics.java
+++ b/src/main/java/com/rackspace/salus/common/config/AutoConfigureSalusAppMetrics.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.common.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Adding this annotation to an application/configuration bean will auto-configure common tags
+ * on the {@link io.micrometer.core.instrument.MeterRegistry}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Configuration
+@Import(MetricsConfig.class)
+public @interface AutoConfigureSalusAppMetrics {
+
+}

--- a/src/main/java/com/rackspace/salus/common/config/MetricsConfig.java
+++ b/src/main/java/com/rackspace/salus/common/config/MetricsConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.common.config;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Customizes the application's {@link MeterRegistry} by adding tags to qualify this application
+ * instance.
+ * <p>
+ *   <em>NOTE</em> it does require that <code>spring.application.name</code> has been declared
+ *   in the application's environment, typically in the <code>application.yml</code>.
+ * </p>
+ */
+@Configuration
+public class MetricsConfig {
+  private final String ourHostname;
+  private final String appName;
+
+  public MetricsConfig(@Value("${spring.application.name}") String appName,
+                       @Value("${localhost.name}") String ourHostName) {
+    this.appName = appName;
+    this.ourHostname = ourHostName;
+  }
+
+  @Bean
+  public MeterRegistryCustomizer<MeterRegistry> metricsCommonTags() {
+    return registry ->
+        registry.config().commonTags(
+            "app", appName,
+            "host", ourHostname);
+  }
+
+}

--- a/src/main/java/com/rackspace/salus/common/config/MetricsConfig.java
+++ b/src/main/java/com/rackspace/salus/common/config/MetricsConfig.java
@@ -21,6 +21,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Customizes the application's {@link MeterRegistry} by adding tags to qualify this application
@@ -35,8 +37,11 @@ public class MetricsConfig {
   private final String ourHostname;
   private final String appName;
 
-  public MetricsConfig(@Value("${spring.application.name}") String appName,
+  public MetricsConfig(@Value("${spring.application.name:}") String appName,
                        @Value("${localhost.name}") String ourHostName) {
+    Assert.state(StringUtils.hasText(appName),
+        "spring.application.name property needs to be set");
+
     this.appName = appName;
     this.ourHostname = ourHostName;
   }

--- a/src/test/java/com/rackspace/salus/common/config/MetricsConfigTest.java
+++ b/src/test/java/com/rackspace/salus/common/config/MetricsConfigTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.common.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {
+    MetricsAutoConfiguration.class,
+    CompositeMeterRegistryAutoConfiguration.class,
+    MetricsConfig.class
+})
+public class MetricsConfigTest {
+
+  @Autowired
+  MeterRegistry meterRegistry;
+
+  @Test
+  public void testMeterRegistryIsCustomized() {
+    meterRegistry.counter("testing");
+
+    meterRegistry.forEachMeter(meter -> {
+      assertThat(meter.getId().getTags())
+          .extracting(Tag::getKey)
+          .contains("app", "host");
+    });
+  }
+}

--- a/src/test/java/com/rackspace/salus/common/config/MetricsConfigTest.java
+++ b/src/test/java/com/rackspace/salus/common/config/MetricsConfigTest.java
@@ -33,6 +33,8 @@ import org.springframework.test.context.junit4.SpringRunner;
     MetricsAutoConfiguration.class,
     CompositeMeterRegistryAutoConfiguration.class,
     MetricsConfig.class
+}, properties = {
+    "spring.application.name=some-test-app"
 })
 public class MetricsConfigTest {
 


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-801 and wanted this during https://jira.rax.io/browse/SALUS-806

# What

We have very similar, but sometimes slightly different, implementations of `MetricsConfig` across some of our apps. It would be good to unify those and avoid re-implementing.

# How

Introduced an annotation `@AutoConfigureSalusAppMetrics` that activates the common `MetricsConfig`. FYI it's an "auto-configure" annotation and not "enable" since the metrics registry is enabled by other means and this is simply auto-configuring that.

# How to test

Added a unit test

# TODO

- [x] Retrofit this into the apps that currently declare their own `MetricsConfig`.
- [ ] Add to apps that currently export app metrics