### PR TITLE
Fix typo in header name

### DIFF
--- a/src/main/java/com/rackspace/salus/common/util/ApiUtils.java
+++ b/src/main/java/com/rackspace/salus/common/util/ApiUtils.java
@@ -25,7 +25,7 @@ public class ApiUtils {
   static final List<String> requiredHeaders = List.of(
       "X-Tenant-Id",
       "X-Roles",
-      "X-Impersonation-Roles",
+      "X-Impersonator-Roles",
       "Content-Type"
   );
 


### PR DESCRIPTION
This is potentially preventing impersonation roles from being passed down to all services.

I say "potentially" because Repose is supposed to merge `X-Impersonator-Roles` into `X-Roles` making this redundant.  Still looking into that part.