### PR TITLE
boolean parser

### DIFF
--- a/src/main/java/com/rackspace/salus/common/errors/BooleanFormatException.java
+++ b/src/main/java/com/rackspace/salus/common/errors/BooleanFormatException.java
@@ -15,20 +15,11 @@
  *
  */
 
-package com.rackspace.salus.common.util;
+package com.rackspace.salus.common.errors;
 
-import com.rackspace.salus.common.errors.BooleanFormatException;
+public class BooleanFormatException extends Exception {
 
-public class BooleanParser {
-
-  public static boolean parseBoolean(String boolValue) throws BooleanFormatException {
-    if("true".compareToIgnoreCase(boolValue) == 0) {
-      return true;
-    }else if ("false".compareToIgnoreCase(boolValue) == 0) {
-      return false;
-    }
-    throw new BooleanFormatException(String.format("%s is not a valid boolean value", boolValue));
+  public BooleanFormatException(String s) {
+    super(s);
   }
-
-
 }

--- a/src/main/java/com/rackspace/salus/common/util/BooleanParser.java
+++ b/src/main/java/com/rackspace/salus/common/util/BooleanParser.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.rackspace.salus.common.util;
+
+public class BooleanParser {
+
+  public static boolean parseBoolean(String boolValue) throws BooleanFormatException {
+    if("true".compareToIgnoreCase(boolValue) == 0) {
+      return true;
+    }else if ("false".compareToIgnoreCase(boolValue) == 0) {
+      return false;
+    }
+    throw new BooleanFormatException(String.format("%s is not a valid boolean value", boolValue));
+  }
+
+  static class BooleanFormatException extends Exception {
+
+    public BooleanFormatException(String s) {
+      super(s);
+    }
+  }
+}

--- a/src/main/java/com/rackspace/salus/common/util/BooleanParser.java
+++ b/src/main/java/com/rackspace/salus/common/util/BooleanParser.java
@@ -22,9 +22,9 @@ import com.rackspace.salus.common.errors.BooleanFormatException;
 public class BooleanParser {
 
   public static boolean parseBoolean(String boolValue) throws BooleanFormatException {
-    if("true".compareToIgnoreCase(boolValue) == 0) {
+    if("true".equalsIgnoreCase(boolValue)) {
       return true;
-    }else if ("false".compareToIgnoreCase(boolValue) == 0) {
+    }else if ("false".equalsIgnoreCase(boolValue)) {
       return false;
     }
     throw new BooleanFormatException(String.format("%s is not a valid boolean value", boolValue));

--- a/src/test/java/com/rackspace/salus/common/util/BooleanParserTest.java
+++ b/src/test/java/com/rackspace/salus/common/util/BooleanParserTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.rackspace.salus.common.util;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.rackspace.salus.common.util.BooleanParser.BooleanFormatException;
+import org.junit.Test;
+
+public class BooleanParserTest {
+  @Test
+  public void parseTrue() throws BooleanFormatException {
+    assertThat(BooleanParser.parseBoolean("True"), equalTo(true));
+  }
+
+  @Test
+  public void parseFalse() throws BooleanFormatException {
+    assertThat(BooleanParser.parseBoolean("FaLse"), equalTo(false));
+  }
+
+  @Test(expected = BooleanFormatException.class)
+  public void parseFails() throws BooleanFormatException {
+    BooleanParser.parseBoolean("not a boolean value");
+  }
+
+}

--- a/src/test/java/com/rackspace/salus/common/util/BooleanParserTest.java
+++ b/src/test/java/com/rackspace/salus/common/util/BooleanParserTest.java
@@ -20,7 +20,7 @@ package com.rackspace.salus.common.util;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import com.rackspace.salus.common.util.BooleanParser.BooleanFormatException;
+import com.rackspace.salus.common.errors.BooleanFormatException;
 import org.junit.Test;
 
 public class BooleanParserTest {


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-783

Adds a new boolean parser for us to use.

This is being added for https://github.com/racker/salus-policy-management/pull/27