### PR TITLE
Use tenant populated from url parsing

### DIFF
--- a/src/main/java/com/rackspace/salus/common/util/ApiUtils.java
+++ b/src/main/java/com/rackspace/salus/common/util/ApiUtils.java
@@ -26,6 +26,7 @@ public class ApiUtils {
       "X-Tenant-Id",
       "X-Roles",
       "X-Impersonator-Roles",
+      "Requested-Tenant-Id",
       "Content-Type"
   );
 

--- a/src/main/java/com/rackspace/salus/common/web/PreAuthenticatedFilter.java
+++ b/src/main/java/com/rackspace/salus/common/web/PreAuthenticatedFilter.java
@@ -76,6 +76,7 @@ public class PreAuthenticatedFilter extends GenericFilterBean {
       }
     }
     final String tenant = req.getHeader(tenantHeader);
+    log.trace("Found tenant {} with roles {} while authenticating", tenant, rolesSet);
 
     if (!rolesSet.isEmpty() && (StringUtils.hasText(tenant))) {
       final List<SimpleGrantedAuthority> roles = rolesSet.stream()

--- a/src/main/java/com/rackspace/salus/common/web/ReposeHeaderFilter.java
+++ b/src/main/java/com/rackspace/salus/common/web/ReposeHeaderFilter.java
@@ -29,7 +29,7 @@ public class ReposeHeaderFilter extends PreAuthenticatedFilter {
 
     public static final String HEADER_X_ROLES = "X-Roles";
     public static final String HEADER_X_IMPERSONATOR_ROLES = "X-Impersonator-Roles";
-    public static final String HEADER_TENANT = "X-Tenant-Id";
+    public static final String HEADER_TENANT = "Requested-Tenant-Id";
 
     public ReposeHeaderFilter() {
         super(HEADER_TENANT, Arrays.asList(HEADER_X_ROLES, HEADER_X_IMPERSONATOR_ROLES));


### PR DESCRIPTION
For tokens with multiple tenants available, Repose will pass down all of them in the `X-Tenant-Id` field.  We only care about the one that the request is specifically for, so we will instead use the tenant that Repose parses out of the URL.

This change will be documented in the `keystone-v2-authorization` filter config.