### PR TITLE
Remove salus-model dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,22 +95,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.rackspace.salus</groupId>
-      <artifactId>salus-telemetry-model</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>spring-boot-starter-jdbc</artifactId>
-          <groupId>org.springframework.boot</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>spring-jdbc</artifactId>
-          <groupId>org.springframework</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
This dependency hasn't been used for a while.  We just need to remove it from the pom.