### PR TITLE
Update authentication filters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
 
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.8.0</version>
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>

--- a/src/main/java/com/rackspace/salus/common/config/RoleProperties.java
+++ b/src/main/java/com/rackspace/salus/common/config/RoleProperties.java
@@ -35,5 +35,5 @@ public class RoleProperties {
    * An anonymous role is used for unauthenticated requests.
    * i.e. internal service-to-service requests.
    */
-  Map<String, String> roleToView = Map.of("ROLE_ANONYMOUS", "ADMIN");
+  Map<String, String> roleToView = Map.of("ROLE_IDENTITY_ADMIN", "ADMIN");
 }

--- a/src/main/java/com/rackspace/salus/common/web/BackendServicesWebSecurityConfig.java
+++ b/src/main/java/com/rackspace/salus/common/web/BackendServicesWebSecurityConfig.java
@@ -61,7 +61,7 @@ public class BackendServicesWebSecurityConfig extends WebSecurityConfigurerAdapt
     http
         .csrf().disable()
         .addFilterBefore(
-            new ReposeHeaderFilter(),
+            new ReposeHeaderFilter(false),
             BasicAuthenticationFilter.class)
         .authorizeRequests()
         .antMatchers("/api/**")

--- a/src/main/java/com/rackspace/salus/common/web/PreAuthenticatedFilter.java
+++ b/src/main/java/com/rackspace/salus/common/web/PreAuthenticatedFilter.java
@@ -109,8 +109,4 @@ public class PreAuthenticatedFilter extends GenericFilterBean {
       return Optional.empty();
     }
   }
-
-  private void returnNoAuthentication() {
-
-  }
 }

--- a/src/main/java/com/rackspace/salus/common/web/ReposeHeaderFilter.java
+++ b/src/main/java/com/rackspace/salus/common/web/ReposeHeaderFilter.java
@@ -31,7 +31,7 @@ public class ReposeHeaderFilter extends PreAuthenticatedFilter {
     public static final String HEADER_X_IMPERSONATOR_ROLES = "X-Impersonator-Roles";
     public static final String HEADER_TENANT = "Requested-Tenant-Id";
 
-    public ReposeHeaderFilter() {
-        super(HEADER_TENANT, Arrays.asList(HEADER_X_ROLES, HEADER_X_IMPERSONATOR_ROLES));
+    public ReposeHeaderFilter(boolean requireTenantId) {
+        super(HEADER_TENANT, Arrays.asList(HEADER_X_ROLES, HEADER_X_IMPERSONATOR_ROLES), requireTenantId);
     }
 }

--- a/src/test/java/com/rackspace/salus/common/web/PreAuthenticatedFilterTest.java
+++ b/src/test/java/com/rackspace/salus/common/web/PreAuthenticatedFilterTest.java
@@ -44,7 +44,7 @@ public class PreAuthenticatedFilterTest {
   @Test
   public void testGetToken() {
     PreAuthenticatedFilter preAuthenticatedFilter = new PreAuthenticatedFilter(HEADER_TENANT,
-        Arrays.asList(HEADER_X_ROLES, HEADER_X_IMPERSONATOR_ROLES));
+        Arrays.asList(HEADER_X_ROLES, HEADER_X_IMPERSONATOR_ROLES), true);
     String userRoles = "monitoring:admin,dedicated:default,ticketing:admin,identity:user-admin";
     String impersonationRoles = "custom:my-admin,salus:admin";
     String tenantId = "12345";
@@ -70,7 +70,7 @@ public class PreAuthenticatedFilterTest {
   @Test
   public void testGetTokenNoRoles() {
     PreAuthenticatedFilter preAuthenticatedFilter = new PreAuthenticatedFilter(HEADER_TENANT,
-        Arrays.asList(HEADER_X_ROLES, HEADER_X_IMPERSONATOR_ROLES));
+        Arrays.asList(HEADER_X_ROLES, HEADER_X_IMPERSONATOR_ROLES), true);
     String tenantId = "12345";
 
     when(servletRequest.getHeader(HEADER_X_ROLES))
@@ -90,7 +90,7 @@ public class PreAuthenticatedFilterTest {
   @Test
   public void testGetTokenSomeRoles() {
     PreAuthenticatedFilter preAuthenticatedFilter = new PreAuthenticatedFilter(HEADER_TENANT,
-        Arrays.asList(HEADER_X_ROLES, HEADER_X_IMPERSONATOR_ROLES));
+        Arrays.asList(HEADER_X_ROLES, HEADER_X_IMPERSONATOR_ROLES), true);
     String userRoles = "monitoring:admin,dedicated:default,ticketing:admin,identity:user-admin";
     String tenantId = "12345";
 
@@ -115,7 +115,7 @@ public class PreAuthenticatedFilterTest {
   @Test
   public void testGetTokenNoTenant() {
     PreAuthenticatedFilter preAuthenticatedFilter = new PreAuthenticatedFilter(HEADER_TENANT,
-        Arrays.asList(HEADER_X_ROLES, HEADER_X_IMPERSONATOR_ROLES));
+        Arrays.asList(HEADER_X_ROLES, HEADER_X_IMPERSONATOR_ROLES), true);
     String userRoles = "monitoring:admin,dedicated:default,ticketing:admin,identity:user-admin";
     String impersonationRoles = "custom:my-admin,salus:admin";
 


### PR DESCRIPTION
# Maven Plugin Change

Some apps were failing to build on 3.7 so I'm bumping the plugin to 3.8 for everything.

The error was something along the lines of `source option 5 is no longer supported` and my search led me to find 3.8 solved this.

# BackendServicesWebSecurityConfig

This deals with role validation and should not care about tenant validation, so we do not require a tenant to be provided.  This service also spans the public and admin api which is another reason for not requiring a tenant (since the admin api does not provide one).

# Other Changes

Updates the Repose Filter so we can tell it whether or not to verify a tenant id was included in the `Requested-Tenant-Id` header.  This is only required for public api requests, so this change allows us to set the option to true for those and false for admin api requests.

It will also now log more useful details for failed requests, for debugging purposes.