### PR TITLE
Fixed null value handling in KafkaErrorConfig

### DIFF
--- a/src/main/java/com/rackspace/salus/common/messaging/KafkaErrorConfig.java
+++ b/src/main/java/com/rackspace/salus/common/messaging/KafkaErrorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,8 +61,9 @@ public class KafkaErrorConfig {
     return (e, data, consumer) -> {
       final String topic = data.topic();
       final int partition = data.partition();
-      final String messageType = data.value().getClass().getSimpleName();
-      final String messageValue = data.value().toString();
+      // for deserialization issues, only the exception will contain the attempted payload
+      final String messageType = data.value() != null ? data.value().getClass().getSimpleName() : null;
+      final String messageValue = data.value() != null ? data.value().toString() : null;
 
       final TopicPartition topicPartition = new TopicPartition(topic, partition);
       log.debug("Handling listener container error by skipping offset={} in={}", data.offset(), topicPartition, e);


### PR DESCRIPTION
# Resolves

Found during https://jira.rax.io/browse/SALUS-927

# What

I'm not sure why this worked before, but the unit test `com.rackspace.salus.event.ingest.services.IngestServiceKafkaTest#testDeserializerFailure` was now hitting an NPE at the changed lines since the value of the given kafka message was null in the case of a deserialization exception.

# How

Wrap access to the `data.value()` with a null check. The debug logging further down in the method will ultimately convey the payload that failed to deserialize.

# How to test

Use `com.rackspace.salus.event.ingest.services.IngestServiceKafkaTest#testDeserializerFailure` in event-engine-ingest.
