### PR TITLE
Changed response message for JsonMappingException

### DIFF
--- a/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
@@ -165,7 +165,7 @@ public abstract class AbstractRestExceptionHandler {
       final JsonMappingException jsonMappingException = (JsonMappingException) e.getCause();
 
       return respondWith(request, HttpStatus.BAD_REQUEST,
-          String.format("Failed to parse JSON at: %s", jsonMappingException.getMessage()));
+          String.format("Failed to parse JSON: %s", jsonMappingException.getMessage()));
     }
     else {
       // fallback to default message derivation

--- a/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
@@ -165,7 +165,7 @@ public abstract class AbstractRestExceptionHandler {
       final JsonMappingException jsonMappingException = (JsonMappingException) e.getCause();
 
       return respondWith(request, HttpStatus.BAD_REQUEST,
-          String.format("Failed to parse JSON at %s", jsonMappingException.getPathReference()));
+          String.format("Failed to parse JSON at: %s", jsonMappingException.getMessage()));
     }
     else {
       // fallback to default message derivation


### PR DESCRIPTION
# Resolves
https://jira.rax.io/browse/SALUS-994

# What
Changed response message for JsonMappingException

# How
Changed AbstractRestExceptionHandler class for JsomMappingException

# How to test
This can be tested via insomnia REST call

# Why
Message displayed for error was not appropriate before