### PR TITLE
Add event topics

### DIFF
--- a/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
+++ b/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
@@ -59,4 +59,10 @@ public class KafkaTopicProperties {
 
   @NotEmpty
   String testEventTaskResults = "telemetry.test-event-task-results.json";
+
+  @NotEmpty
+  String kapacitorEvents = "salus.kapacitor-events.json";
+
+  @NotEmpty
+  String stateChangeEvents = "salus.state-change-events.json";
 }

--- a/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
+++ b/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
@@ -61,8 +61,5 @@ public class KafkaTopicProperties {
   String testEventTaskResults = "telemetry.test-event-task-results.json";
 
   @NotEmpty
-  String kapacitorEvents = "salus.kapacitor-events.json";
-
-  @NotEmpty
   String stateChangeEvents = "salus.state-change-events.json";
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-1036

# What

A new topic where state change events can be sent.

These are generated by the event-engine-processor based on the state expressions within a task.