### PR TITLE
Added exception handler for MethodArgumentNotValidException

### DIFF
--- a/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
@@ -103,7 +103,6 @@ public abstract class AbstractRestExceptionHandler {
     }
     body.put("status", status.value());
     body.put("error", status.getReasonPhrase());
-    body.remove("errors");
     if (message != null) {
       body.put("message", message);
     }
@@ -184,7 +183,13 @@ public abstract class AbstractRestExceptionHandler {
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<?> handleMethodArgumentNotValidException(HttpServletRequest request, MethodArgumentNotValidException e) {
     logRequestFailure(request, e);
-    return respondWith(request, HttpStatus.BAD_REQUEST, e.getMessage());
+    StringBuilder message = new StringBuilder();
+    e.getBindingResult().getFieldErrors().stream().forEach(error -> {
+      message.append("Validation failed for [field]: ").append(error.getField())
+          .append(" with [message]: ").append(error.getDefaultMessage()).append(", ");
+    });
+    message.delete(message.length() - 2, message.length());
+    return respondWith(request, HttpStatus.BAD_REQUEST, message.toString());
   }
 
 }

--- a/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.rackspace.salus.common.errors.ResponseMessages;
 import com.rackspace.salus.common.errors.RuntimeKafkaException;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
@@ -183,13 +184,11 @@ public abstract class AbstractRestExceptionHandler {
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<?> handleMethodArgumentNotValidException(HttpServletRequest request, MethodArgumentNotValidException e) {
     logRequestFailure(request, e);
-    StringBuilder message = new StringBuilder();
-    e.getBindingResult().getFieldErrors().stream().forEach(error -> {
-      message.append("Validation failed for [field]: ").append(error.getField())
-          .append(" with [message]: ").append(error.getDefaultMessage()).append(", ");
-    });
-    message.delete(message.length() - 2, message.length());
-    return respondWith(request, HttpStatus.BAD_REQUEST, message.toString());
+    String message = "One or more field validations failed: " +
+        e.getBindingResult().getFieldErrors().stream()
+            .map(error -> error.getField() + " " + error.getDefaultMessage())
+            .collect(Collectors.joining(", "));
+    return respondWith(request, HttpStatus.BAD_REQUEST, message);
   }
 
 }

--- a/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
@@ -186,7 +186,7 @@ public abstract class AbstractRestExceptionHandler {
     logRequestFailure(request, e);
     String message = "One or more field validations failed: " +
         e.getBindingResult().getFieldErrors().stream()
-            .map(error -> error.getField() + " " + error.getDefaultMessage())
+            .map(error -> error.getField())
             .collect(Collectors.joining(", "));
     return respondWith(request, HttpStatus.BAD_REQUEST, message);
   }

--- a/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
@@ -27,6 +27,7 @@ import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClientException;
@@ -102,6 +103,7 @@ public abstract class AbstractRestExceptionHandler {
     }
     body.put("status", status.value());
     body.put("error", status.getReasonPhrase());
+    body.remove("errors");
     if (message != null) {
       body.put("message", message);
     }
@@ -177,6 +179,12 @@ public abstract class AbstractRestExceptionHandler {
   public ResponseEntity<?> handleKafkaExceptions(HttpServletRequest request, Exception e) {
     logRequestFailure(request, e);
     return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.kafkaExceptionMessage);
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<?> handleMethodArgumentNotValidException(HttpServletRequest request, MethodArgumentNotValidException e) {
+    logRequestFailure(request, e);
+    return respondWith(request, HttpStatus.BAD_REQUEST, e.getMessage());
   }
 
 }


### PR DESCRIPTION
# Resolves
https://jira.rax.io/browse/SALUS-730

# What
Handling of MethodArgumentNotValidException for inconsistent error messages.

# How to test
This can be tested via REST call

#  Example

**Before**
`{
  "timestamp": "2020-09-23T11:01:50.037+00:00",
  "status": 400,
  "error": "Bad Request",
  "exception": "org.springframework.web.bind.MethodArgumentNotValidException",
  "message": "",
  "path": "/api/admin/zones",
  "app": "salus-telemetry-monitor-management",
  "host": "MCP2AKMD6M"
}`

**After**
`{
  "timestamp": "2020-09-23T11:00:05.364+00:00",
  "status": 400,
  "error": "Bad Request",
  "exception": "org.springframework.web.bind.MethodArgumentNotValidException",
  "message": "Validation failed for argument [0] in public com.rackspace.salus.monitor_management.web.model.ZoneDTO com.rackspace.salus.monitor_management.web.controller.ZoneApiController.create(com.rackspace.salus.monitor_management.web.model.ZoneCreatePublic) throws com.rackspace.salus.telemetry.errors.AlreadyExistsException: [Field error in object 'zoneCreatePublic' on field 'name': rejected value [invalid/zone]; codes [PublicZoneName.zoneCreatePublic.name,PublicZoneName.name,PublicZoneName.java.lang.String,PublicZoneName]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [zoneCreatePublic.name,name]; arguments []; default message [name]]; default message [zone name must be public]] ",
  "app": "salus-telemetry-monitor-management",
  "host": "MCP2AKMD6M",
  "traceId": "804898f212702665"
}`