### PR TITLE
Handled case for JsonParseException in IllegalStateException handler

### DIFF
--- a/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
@@ -144,8 +144,10 @@ public abstract class AbstractRestExceptionHandler {
   public ResponseEntity<?> handleBadState(HttpServletRequest request, Exception e) {
 
     logRequestFailure(request, e);
-    if (e.getCause().getCause() instanceof JsonParseException) {
-      return respondWith(request, HttpStatus.BAD_REQUEST, e.getCause().getCause().getMessage());
+    if (e.getCause() instanceof HttpMessageNotReadableException) {
+      if (e.getCause().getCause() instanceof JsonParseException) {
+        return respondWith(request, HttpStatus.BAD_REQUEST, e.getCause().getCause().getMessage());
+      }
     }
     return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR);
   }

--- a/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.common.web;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.rackspace.salus.common.errors.ResponseMessages;
 import com.rackspace.salus.common.errors.RuntimeKafkaException;
@@ -143,8 +144,8 @@ public abstract class AbstractRestExceptionHandler {
   public ResponseEntity<?> handleBadState(HttpServletRequest request, Exception e) {
 
     logRequestFailure(request, e);
-    if (e.getCause() instanceof HttpMessageNotReadableException) {
-      return respondWith(request, HttpStatus.BAD_REQUEST, e.getCause().getMessage());
+    if (e.getCause().getCause() instanceof JsonParseException) {
+      return respondWith(request, HttpStatus.BAD_REQUEST, e.getCause().getCause().getMessage());
     }
     return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR);
   }

--- a/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/common/web/AbstractRestExceptionHandler.java
@@ -143,6 +143,9 @@ public abstract class AbstractRestExceptionHandler {
   public ResponseEntity<?> handleBadState(HttpServletRequest request, Exception e) {
 
     logRequestFailure(request, e);
+    if (e.getCause() instanceof HttpMessageNotReadableException) {
+      return respondWith(request, HttpStatus.BAD_REQUEST, e.getCause().getMessage());
+    }
     return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 


### PR DESCRIPTION
# Resolves
https://jira.rax.io/browse/SALUS-827

# What
Handle case for HttpMessageNotReadableException in IllegalStateException handler

# How to test
This can be tested via REST call

#  Example

**Before**
![image](https://user-images.githubusercontent.com/13554835/94555461-3fd2a580-0279-11eb-84ca-9b64528ac616.png)

**After**
![image](https://user-images.githubusercontent.com/13554835/94555528-5547cf80-0279-11eb-906a-c976c60968e6.png)
