### PR TITLE
Add more standard metric names/tags

### DIFF
--- a/src/main/java/com/rackspace/salus/common/config/MetricNames.java
+++ b/src/main/java/com/rackspace/salus/common/config/MetricNames.java
@@ -19,4 +19,5 @@ package com.rackspace.salus.common.config;
 public interface MetricNames {
   String SERVICE_OPERATION_SUCCEEDED = "service_operations_succeeded";
   String SERVICE_OPERATION_FAILED = "service_operations_failed";
+  String SILENT_ERRORS = "silent_errors";
 }

--- a/src/main/java/com/rackspace/salus/common/config/MetricTags.java
+++ b/src/main/java/com/rackspace/salus/common/config/MetricTags.java
@@ -22,4 +22,5 @@ public interface MetricTags {
   String OBJECT_TYPE_METRIC_TAG = "objectType";
   String EXCEPTION_METRIC_TAG = "exception";
   String URI_METRIC_TAG = "uri";
+  String REASON = "reason";
 }


### PR DESCRIPTION
Some new names that I'm using in https://github.com/racker/salus-event-engine-processor/pull/1

I considered "ignored_errors" instead of "silent" but in the end we dont want to ignore them which is why they're tracked here... they just don't cause any exceptions to be thrown.