### PR TITLE
Add value to track partition count

### DIFF
--- a/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
+++ b/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.common.messaging;
 
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -26,6 +27,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("salus.kafka.topics")
 @Data
 public class KafkaTopicProperties {
+
+  @NotNull
+  Integer metricsTopicPartitions = 64;
 
   @NotEmpty
   String logs = "telemetry.logs.json";

--- a/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
+++ b/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
@@ -28,6 +28,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Data
 public class KafkaTopicProperties {
 
+  /**
+   * This value should match the number of partitions configured for the topic
+   * containing enriched metrics.
+   */
   @NotNull
   Integer metricsTopicPartitions = 64;
 


### PR DESCRIPTION
# What

Used with https://github.com/racker/salus-event-engine-management/pull/75

To be able to generate a partitionid for a task we need to know the total number of partitions on the metrics topic.
