### PR TITLE
Renamed event notifications topic

### DIFF
--- a/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
+++ b/src/main/java/com/rackspace/salus/common/messaging/KafkaTopicProperties.java
@@ -75,5 +75,5 @@ public class KafkaTopicProperties {
   String testEventTaskResults = "telemetry.test-event-task-results.json";
 
   @NotEmpty
-  String stateChangeEvents = "salus.state-change-events.json";
+  String eventNotifications = "salus.event-notifications.json";
 }


### PR DESCRIPTION
# Part of

https://jira.rax.io/browse/SALUS-1078

# What

To line up better with v1 alarm notifications, renamed the topic to use the "event notifications" phrasing.